### PR TITLE
Prepare for release 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This is incredibly useful for:
 Add the dependency below to your `libs.versions.toml` file:
 
 ```toml
-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.4.0" }
+stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.4.1" }
 ```
 
 Next, apply the plugin on your root's `build.gradle.kts` file like below:
@@ -135,8 +135,9 @@ alias(libs.plugins.stability.analyzer)
 It’s **strongly recommended to use the exact same Kotlin version** as this library. Using a different Kotlin version may lead to compilation errors during the build process.
 
 | Stability Analyzer | Kotlin |
-|-------------|-------------|
-| 0.4.0       | 2.2.21 |
+|--------------------|-------------|
+| 0.4.1              | 2.2.21 |
+| 0.4.0              | 2.2.21 |
 
 ### TraceRecomposition Annotation
 

--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
+## [0.4.1] - 2025-11-02
+
+### Fixed
+- Fixed stability analysis for Compose shape types (RoundedCornerShape, CircleShape, etc.) to correctly show as STABLE instead of RUNTIME
+- Improved consistency between IDEA plugin and compiler plugin stability inference
+- Added Compose Foundation shapes to known stable types list
+
+### Improved
+- Enhanced accuracy of stability analysis to match compiler plugin behavior
+
+---
+
 ## [0.4.0] - 2025-11-02
 
 ### Added


### PR DESCRIPTION
Prepare for release 0.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stability analysis for Compose shape types
  * Improved stability analysis accuracy to align with compiler plugin behavior
  * Added Compose Foundation shapes to recognized stable types

* **Documentation**
  * Updated version references to 0.4.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->