### PR TITLE
Prevent recursive detection for the complicated type structures

### DIFF
--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
 ### Fixed
 - Fixed stability analysis for Compose shape types (RoundedCornerShape, CircleShape, etc.) to correctly show as STABLE instead of RUNTIME
+- Fixed StackOverflowError when analyzing recursive or self-referential types (Issue #11)
 - Improved consistency between IDEA plugin and compiler plugin stability inference
 - Added Compose Foundation shapes to known stable types list
+- Added cycle detection to prevent infinite recursion in type stability analysis
 
 ### Improved
 - Enhanced accuracy of stability analysis to match compiler plugin behavior
+- Better handling of complex function type aliases and deeply nested generic types
 
 ---
 


### PR DESCRIPTION
Prevent recursive detection for the complicated type structures. (#11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during stability analysis of recursive and self-referential types
  * Added cycle detection to prevent infinite recursion in type stability analysis
  * Enhanced handling of complex function type aliases and deeply nested generic types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->