### PR TITLE
Expand typealiases first - resolve typealias to actual type

### DIFF
--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Fixed typealias detection for Composable function types (Issue #16)
+- Typealiases like `typealias SettingsButtons = @Composable (PlayerUiState) -> Unit` now correctly expand to their underlying function types before stability analysis
+
+---
+
 ## [0.4.2] - 2025-11-03
 
 ### Fixed


### PR DESCRIPTION
Expand typealiases first - resolve typealias to actual type. (#16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typealias expansion in stability analysis. Composable function typealiases now correctly expand to their underlying types before analysis, improving detection accuracy for complex type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->