### PR TITLE
Add an option for showing gutter icons in test source sets

### DIFF
--- a/app/src/main/kotlin/com/skydoves/myapplication/MainActivity.kt
+++ b/app/src/main/kotlin/com/skydoves/myapplication/MainActivity.kt
@@ -209,6 +209,7 @@ fun UnstableUser.Test(stableUser2: StableUser) {
 fun Test(
   myClass2: MyClass2,
   normalClass: NormalClass,
+  immutableList: ImmutableList<String>,
 ) {
 }
 

--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- New setting: "Show in test source sets" for gutter icons (Issue #21)
+- Gutter icons are now hidden in test directories by default (can be enabled in settings)
+
 ### Fixed
 - Fixed typealias detection for Composable function types (Issue #16)
 - Typealiases like `typealias SettingsButtons = @Composable (PlayerUiState) -> Unit` now correctly expand to their underlying function types before stability analysis
+- Fixed ImmutableList/ImmutableSet/ImmutableMap showing as unstable in test code (Issue #21)
+- Added fallback type resolution by simple name for immutable collections when FQN resolution fails in test source sets
 
 ---
 

--- a/compose-stability-analyzer-idea/api/compose-stability-analyzer-idea.api
+++ b/compose-stability-analyzer-idea/api/compose-stability-analyzer-idea.api
@@ -96,6 +96,7 @@ public final class com/skydoves/compose/stability/idea/settings/StabilitySetting
 	public final fun getRuntimeGutterColorRGB ()I
 	public final fun getRuntimeHintColorRGB ()I
 	public final fun getShowGutterIcons ()Z
+	public final fun getShowGutterIconsInTests ()Z
 	public final fun getShowGutterIconsOnlyForUnskippable ()Z
 	public final fun getShowInlineHints ()Z
 	public final fun getShowOnlyUnstableHints ()Z
@@ -115,6 +116,7 @@ public final class com/skydoves/compose/stability/idea/settings/StabilitySetting
 	public final fun setRuntimeGutterColorRGB (I)V
 	public final fun setRuntimeHintColorRGB (I)V
 	public final fun setShowGutterIcons (Z)V
+	public final fun setShowGutterIconsInTests (Z)V
 	public final fun setShowGutterIconsOnlyForUnskippable (Z)V
 	public final fun setShowInlineHints (Z)V
 	public final fun setShowOnlyUnstableHints (Z)V

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityLineMarkerProvider.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityLineMarkerProvider.kt
@@ -18,6 +18,7 @@ package com.skydoves.compose.stability.idea
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.openapi.roots.TestSourcesFilter
 import com.intellij.psi.PsiElement
 import com.intellij.util.ui.ColorIcon
 import com.intellij.util.ui.JBUI
@@ -51,6 +52,18 @@ public class StabilityLineMarkerProvider : LineMarkerProvider {
 
     if (function.isPreview()) {
       return null
+    }
+
+    // Check if we should show gutter icons in test code
+    if (!settings.showGutterIconsInTests) {
+      val containingFile = function.containingFile.virtualFile
+      if (containingFile != null) {
+        val project = function.project
+        // Check if the file is in a test source set
+        if (TestSourcesFilter.isTestSources(containingFile, project)) {
+          return null
+        }
+      }
     }
 
     val analysis = try {

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
@@ -292,6 +292,27 @@ internal class KtStabilityInferencer {
       }
     }
 
+    // 13b. Fallback check for immutable collections by simple name (for test code where FQN might not resolve)
+    if (simpleName.contains("Immutable") || simpleName.contains("Persistent")) {
+      // Double-check it's actually an immutable collection type
+      if (simpleName in setOf(
+          "ImmutableList",
+          "ImmutableSet",
+          "ImmutableMap",
+          "ImmutableCollection",
+          "PersistentList",
+          "PersistentSet",
+          "PersistentMap",
+          "PersistentCollection",
+        )
+      ) {
+        return KtStability.Certain(
+          stable = true,
+          reason = "Immutable collection (resolved by simple name)",
+        )
+      }
+    }
+
     // 14. Standard collections (List, Set, Map) - RUNTIME check needed
     if (fqName != null && StabilityAnalysisConstants.isStandardCollection(fqName)) {
       return KtStability.Runtime(className = fqName)

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilitySettingsConfigurable.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilitySettingsConfigurable.kt
@@ -78,6 +78,14 @@ public class StabilitySettingsConfigurable : BoundConfigurable("Compose Stabilit
               .bindSelected(settings::showGutterIconsOnlyForUnskippable)
               .comment("When enabled, only unskippable composables will show gutter icons")
           }
+
+          row {
+            checkBox("Show in test source sets")
+              .bindSelected(settings::showGutterIconsInTests)
+              .comment(
+                "When enabled, gutter icons will appear in test directories (disabled by default)",
+              )
+          }
         }
 
         row {

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilitySettingsState.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilitySettingsState.kt
@@ -59,6 +59,12 @@ public class StabilitySettingsState : PersistentStateComponent<StabilitySettings
   public var showGutterIconsOnlyForUnskippable: Boolean = false
 
   /**
+   * Show gutter icons in test source sets.
+   * When disabled, gutter icons will not appear for composables in test directories.
+   */
+  public var showGutterIconsInTests: Boolean = false
+
+  /**
    * Show warning annotations (underlines and tooltips) for unstable composables and parameters.
    */
   public var showWarnings: Boolean = true


### PR DESCRIPTION
Add an option for showing gutter icons in test source sets (#21)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to toggle gutter icon visibility in test source sets.
  * Improved type resolution for immutable collections in test code with fallback simple name matching.

* **Bug Fixes**
  * Fixed incorrect display of immutable collection types (ImmutableList, ImmutableSet, ImmutableMap) as unstable in test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->