### PR TITLE
Enhance the window tool header guides

### DIFF
--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/StabilityNodeData.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/StabilityNodeData.kt
@@ -60,6 +60,14 @@ public sealed class StabilityNodeData {
   public data class EmptyMessage(
     val message: String,
   ) : StabilityNodeData()
+
+  /**
+   * Clickable GitHub link node
+   */
+  public data class GitHubLink(
+    val text: String,
+    val url: String,
+  ) : StabilityNodeData()
 }
 
 /**


### PR DESCRIPTION
Enhance the window tool header guides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clickable GitHub links within the stability tree that open directly in your browser on single-click
  * Enhanced empty-state view with structured steps and integrated GitHub link navigation
  * Preserved double-click navigation functionality for composables while enabling link interaction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->