### PR TITLE
Prevent toString to use Kotlin reflection to get function metadata

### DIFF
--- a/stability-runtime/src/androidMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.android.kt
+++ b/stability-runtime/src/androidMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.android.kt
@@ -51,13 +51,13 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
 
       val status = when {
         change.changed -> {
-          val oldStr = change.oldValue?.toString() ?: "null"
-          val newStr = change.newValue?.toString() ?: "null"
+          val oldStr = safeToString(change.oldValue)
+          val newStr = safeToString(change.newValue)
           "changed ($oldStr → $newStr)"
         }
 
-        change.stable -> "stable (${change.newValue})"
-        else -> "unstable (${change.newValue})"
+        change.stable -> "stable (${safeToString(change.newValue)})"
+        else -> "unstable (${safeToString(change.newValue)})"
       }
 
       Log.d(tag, "$prefix ${change.name}: ${change.type} $status")
@@ -66,6 +66,21 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
     // Log unstable parameters summary
     if (event.unstableParameters.isNotEmpty()) {
       Log.d(tag, "  └─ Unstable parameters: ${event.unstableParameters}")
+    }
+  }
+
+  /**
+   * Safely converts a value to string, handling reflection errors.
+   * Falls back to a simple representation if toString() throws an exception.
+   */
+  private fun safeToString(value: Any?): String {
+    if (value == null) return "null"
+
+    return try {
+      value.toString()
+    } catch (e: Throwable) {
+      // Fallback for any toString() failures (including reflection errors)
+      "${value.javaClass.simpleName}@${value.hashCode().toString(16)}"
     }
   }
 }

--- a/stability-runtime/src/jvmMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.jvm.kt
+++ b/stability-runtime/src/jvmMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.jvm.kt
@@ -42,13 +42,13 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
 
       val status = when {
         change.changed -> {
-          val oldStr = change.oldValue?.toString() ?: "null"
-          val newStr = change.newValue?.toString() ?: "null"
+          val oldStr = safeToString(change.oldValue)
+          val newStr = safeToString(change.newValue)
           "changed ($oldStr → $newStr)"
         }
 
-        change.stable -> "stable (${change.newValue})"
-        else -> "unstable (${change.newValue})"
+        change.stable -> "stable (${safeToString(change.newValue)})"
+        else -> "unstable (${safeToString(change.newValue)})"
       }
 
       println("$prefix ${change.name}: ${change.type} $status")
@@ -57,6 +57,21 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
     // Log unstable parameters summary
     if (event.unstableParameters.isNotEmpty()) {
       println("  └─ Unstable parameters: ${event.unstableParameters}")
+    }
+  }
+
+  /**
+   * Safely converts a value to string, handling reflection errors.
+   * Falls back to a simple representation if toString() throws an exception.
+   */
+  private fun safeToString(value: Any?): String {
+    if (value == null) return "null"
+
+    return try {
+      value.toString()
+    } catch (e: Throwable) {
+      // Fallback for any toString() failures (including reflection errors)
+      "${value.javaClass.simpleName}@${value.hashCode().toString(16)}"
     }
   }
 }

--- a/stability-runtime/src/skiaMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.ios.kt
+++ b/stability-runtime/src/skiaMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.ios.kt
@@ -42,13 +42,13 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
 
       val status = when {
         change.changed -> {
-          val oldStr = change.oldValue?.toString() ?: "null"
-          val newStr = change.newValue?.toString() ?: "null"
+          val oldStr = safeToString(change.oldValue)
+          val newStr = safeToString(change.newValue)
           "changed ($oldStr → $newStr)"
         }
 
-        change.stable -> "stable (${change.newValue})"
-        else -> "unstable (${change.newValue})"
+        change.stable -> "stable (${safeToString(change.newValue)})"
+        else -> "unstable (${safeToString(change.newValue)})"
       }
 
       println("$prefix ${change.name}: ${change.type} $status")
@@ -57,6 +57,22 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
     // Log unstable parameters summary
     if (event.unstableParameters.isNotEmpty()) {
       println("  └─ Unstable parameters: ${event.unstableParameters}")
+    }
+  }
+
+  /**
+   * Safely converts a value to string, handling function types and reflection errors.
+   * Falls back to a simple representation if toString() throws an exception.
+   */
+  private fun safeToString(value: Any?): String {
+    if (value == null) return "null"
+
+    return try {
+      value.toString()
+    } catch (e: Throwable) {
+      // Fallback for any toString() failures (including reflection errors)
+      // On iOS/native, we don't have javaClass.simpleName, so use a simpler approach
+      "Object@${value.hashCode().toString(16)}"
     }
   }
 }

--- a/stability-runtime/src/wasmJsMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.wasmJs.kt
+++ b/stability-runtime/src/wasmJsMain/kotlin/com/skydoves/compose/stability/runtime/DefaultRecompositionLogger.wasmJs.kt
@@ -42,13 +42,13 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
 
       val status = when {
         change.changed -> {
-          val oldStr = change.oldValue?.toString() ?: "null"
-          val newStr = change.newValue?.toString() ?: "null"
+          val oldStr = safeToString(change.oldValue)
+          val newStr = safeToString(change.newValue)
           "changed ($oldStr → $newStr)"
         }
 
-        change.stable -> "stable (${change.newValue})"
-        else -> "unstable (${change.newValue})"
+        change.stable -> "stable (${safeToString(change.newValue)})"
+        else -> "unstable (${safeToString(change.newValue)})"
       }
 
       println("$prefix ${change.name}: ${change.type} $status")
@@ -57,6 +57,22 @@ public actual class DefaultRecompositionLogger : RecompositionLogger {
     // Log unstable parameters summary
     if (event.unstableParameters.isNotEmpty()) {
       println("  └─ Unstable parameters: ${event.unstableParameters}")
+    }
+  }
+
+  /**
+   * Safely converts a value to string, handling function types and reflection errors.
+   * Falls back to a simple representation if toString() throws an exception.
+   */
+  private fun safeToString(value: Any?): String {
+    if (value == null) return "null"
+
+    return try {
+      value.toString()
+    } catch (e: Throwable) {
+      // Fallback for any toString() failures (including reflection errors)
+      // On Wasm, we don't have javaClass.simpleName, so use a simpler approach
+      "Object@${value.hashCode().toString(16)}"
     }
   }
 }


### PR DESCRIPTION
Prevent toString to use Kotlin reflection to get function metadata. (#49 )

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recomposition logging robustness across all platforms (Android, JVM, iOS, WebAssembly). Logging now gracefully handles edge cases where value string conversion may fail, ensuring reliable logging even with complex object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->