### PR TITLE
Implement failOnStabilityChange property for the gradle plugin

### DIFF
--- a/stability-gradle/api/stability-gradle.api
+++ b/stability-gradle/api/stability-gradle.api
@@ -23,6 +23,7 @@ public final class com/skydoves/compose/stability/gradle/StabilityAnalyzerGradle
 public abstract class com/skydoves/compose/stability/gradle/StabilityCheckTask : org/gradle/api/DefaultTask {
 	public fun <init> ()V
 	public final fun check ()V
+	public abstract fun getFailOnStabilityChange ()Lorg/gradle/api/provider/Property;
 	public abstract fun getIgnoredClasses ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoredPackages ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getProjectName ()Lorg/gradle/api/provider/Property;
@@ -43,6 +44,7 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityDumpTask : 
 public abstract class com/skydoves/compose/stability/gradle/StabilityValidationConfig {
 	public fun <init> (Lorg/gradle/api/file/ProjectLayout;Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
+	public final fun getFailOnStabilityChange ()Lorg/gradle/api/provider/Property;
 	public final fun getIgnoredClasses ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getIgnoredPackages ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getIgnoredProjects ()Lorg/gradle/api/provider/ListProperty;

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
@@ -132,4 +132,12 @@ public abstract class StabilityValidationConfig @Inject constructor(
    */
   public val ignoredClasses: ListProperty<String> =
     objects.listProperty(String::class.java).convention(emptyList())
+
+  /**
+   * Whether to fail the build when stability changes are detected.
+   * When false, stability changes will be logged as warnings instead.
+   * Default: true
+   */
+  public val failOnStabilityChange: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(true)
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -89,6 +89,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       stabilityDir.set(extension.stabilityValidation.outputDir)
       ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
       ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
+      failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
     }
 
     // Make check task depend on stabilityCheck if enabled (only if check task exists)


### PR DESCRIPTION
Implement failOnStabilityChange property for the gradle plugin. (#52)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `failOnStabilityChange` configuration option for the Stability Gradle plugin. When enabled (default), the build fails if stability changes are detected. When disabled, stability changes are logged as warnings, allowing the build to continue while maintaining visibility of composition stability changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->