### PR TITLE
Change configuration scopes from to application to project

### DIFF
--- a/compose-stability-analyzer-idea/api/compose-stability-analyzer-idea.api
+++ b/compose-stability-analyzer-idea/api/compose-stability-analyzer-idea.api
@@ -79,8 +79,24 @@ public final class com/skydoves/compose/stability/idea/quickfix/AddTraceRecompos
 	public fun isAvailable (Lcom/intellij/openapi/project/Project;Lcom/intellij/openapi/editor/Editor;Lcom/intellij/psi/PsiElement;)Z
 }
 
-public final class com/skydoves/compose/stability/idea/settings/StabilitySettingsConfigurable : com/intellij/openapi/options/BoundConfigurable {
+public final class com/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState : com/intellij/openapi/components/PersistentStateComponent {
+	public static final field Companion Lcom/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState$Companion;
 	public fun <init> ()V
+	public final fun getCustomStableTypesAsRegex ()Ljava/util/List;
+	public final fun getStabilityConfigurationPath ()Ljava/lang/String;
+	public fun getState ()Lcom/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState;
+	public synthetic fun getState ()Ljava/lang/Object;
+	public fun loadState (Lcom/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState;)V
+	public synthetic fun loadState (Ljava/lang/Object;)V
+	public final fun setStabilityConfigurationPath (Ljava/lang/String;)V
+}
+
+public final class com/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState$Companion {
+	public final fun getInstance (Lcom/intellij/openapi/project/Project;)Lcom/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState;
+}
+
+public final class com/skydoves/compose/stability/idea/settings/StabilitySettingsConfigurable : com/intellij/openapi/options/BoundConfigurable {
+	public fun <init> (Lcom/intellij/openapi/project/Project;)V
 	public fun apply ()V
 	public fun createPanel ()Lcom/intellij/openapi/ui/DialogPanel;
 	public fun isModified ()Z

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/StabilityAnalyzerK2.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/StabilityAnalyzerK2.kt
@@ -72,7 +72,7 @@ internal object StabilityAnalyzerK2 {
   private fun analyzeWithK2Session(function: KtNamedFunction): ComposableStabilityInfo {
     // Get function symbol
     val functionSymbol = function.symbol
-    val inferencer = KtStabilityInferencer()
+    val inferencer = KtStabilityInferencer(function.project)
 
     // Analyze value parameters
     val parameters = functionSymbol.valueParameters.map { param ->

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/settings/StabilityProjectSettingsState.kt
@@ -1,0 +1,92 @@
+/*
+ * Designed and developed by 2025 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.compose.stability.idea.settings
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.StoragePathMacros
+import com.intellij.openapi.project.Project
+import com.intellij.util.xmlb.XmlSerializerUtil
+
+/**
+ * Project-level settings for Compose Stability Analyzer plugin.
+ * These settings are stored per-project in .idea/composeStabilityProject.xml
+ */
+@Service(Service.Level.PROJECT)
+@State(
+  name = "ComposeStabilityProjectSettings",
+  storages = [Storage(StoragePathMacros.WORKSPACE_FILE)],
+)
+public class StabilityProjectSettingsState :
+  PersistentStateComponent<StabilityProjectSettingsState> {
+
+  /**
+   * Path to external stability configuration file for this project.
+   * This file can define custom stable types and ignored patterns.
+   */
+  public var stabilityConfigurationPath: String = ""
+
+  public override fun getState(): StabilityProjectSettingsState = this
+
+  public override fun loadState(state: StabilityProjectSettingsState) {
+    XmlSerializerUtil.copyBean(state, this)
+  }
+
+  /**
+   * Get custom stable type patterns from configuration file.
+   */
+  public fun getCustomStableTypesAsRegex(): List<Regex> {
+    if (stabilityConfigurationPath.isEmpty()) {
+      return emptyList()
+    }
+
+    return try {
+      val file = java.io.File(stabilityConfigurationPath)
+      if (!file.exists() || !file.isFile) {
+        return emptyList()
+      }
+
+      val patterns = mutableListOf<String>()
+      file.readLines().forEach { line ->
+        val trimmed = line.trim()
+        if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+          patterns.add(trimmed)
+        }
+      }
+
+      patterns.mapNotNull { pattern ->
+        try {
+          pattern
+            .replace(".", "\\.")
+            .replace("*", ".*")
+            .toRegex()
+        } catch (e: Exception) {
+          null
+        }
+      }
+    } catch (e: Exception) {
+      emptyList()
+    }
+  }
+
+  public companion object {
+    public fun getInstance(project: Project): StabilityProjectSettingsState {
+      return project.getService(StabilityProjectSettingsState::class.java)
+    }
+  }
+}

--- a/compose-stability-analyzer-idea/src/main/resources/META-INF/plugin.xml
+++ b/compose-stability-analyzer-idea/src/main/resources/META-INF/plugin.xml
@@ -39,11 +39,15 @@
         <applicationService
                 serviceImplementation="com.skydoves.compose.stability.idea.settings.StabilitySettingsState"/>
 
-        <applicationConfigurable
+        <projectService
+                serviceImplementation="com.skydoves.compose.stability.idea.settings.StabilityProjectSettingsState"/>
+
+        <projectConfigurable
                 parentId="tools"
                 instance="com.skydoves.compose.stability.idea.settings.StabilitySettingsConfigurable"
                 id="com.skydoves.compose.stability.idea.settings.StabilitySettingsConfigurable"
-                displayName="Compose Stability Analyzer"/>
+                displayName="Compose Stability Analyzer"
+                nonDefaultProject="true"/>
 
         <!-- Documentation provider for hover tooltips -->
         <lang.documentationProvider

--- a/stability-compiler/api/stability-compiler.api
+++ b/stability-compiler/api/stability-compiler.api
@@ -114,6 +114,7 @@ public final class com/skydoves/compose/stability/compiler/StabilityAnalyzerIrGe
 
 public final class com/skydoves/compose/stability/compiler/StabilityAnalyzerPluginRegistrar : org/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar {
 	public fun <init> ()V
+	public final fun getPluginId ()Ljava/lang/String;
 	public fun getSupportsK2 ()Z
 	public fun registerExtensions (Lorg/jetbrains/kotlin/compiler/plugin/CompilerPluginRegistrar$ExtensionStorage;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
 }

--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerPluginRegistrar.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerPluginRegistrar.kt
@@ -26,6 +26,8 @@ public class StabilityAnalyzerPluginRegistrar : CompilerPluginRegistrar() {
 
   override val supportsK2: Boolean = true
 
+  public val pluginId: String = StabilityAnalyzerCommandLineProcessor.PLUGIN_ID
+
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
     val enabled = configuration.get(StabilityAnalyzerConfigurationKeys.KEY_ENABLED, true)
 


### PR DESCRIPTION
Change configuration scopes from to application to project. (#60)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stability analyzer configuration is now scoped per-project instead of globally, allowing each project to maintain independent custom stable type definitions and analysis settings.
  * Project-level settings panel accessible via Tools menu for configuring the Compose Stability Analyzer plugin per-project.
  * Per-project configuration persistence, enabling team members to maintain project-specific stability configurations without affecting other projects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->