### PR TITLE
Fix ignored patterns was not applied to window tool properly

### DIFF
--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to the IntelliJ IDEA plugin will be documented in this file.
   - Double-clicking on property names in tool window now navigates to correct source location
   - Extended source location search to include `KtProperty` declarations in addition to `KtNamedFunction`
 
+### Improved
+- **Enhanced tool window handling of ignored type patterns** (Issue #74)
+  - Ignored parameters are now displayed as stable instead of being hidden completely
+  - Composable skippability is recalculated based on processed parameters after applying ignore patterns
+  - Composables with only ignored unstable parameters now correctly show as skippable
+  - Provides better visibility of composable signatures while respecting ignore patterns
+
 ---
 
 ## [0.6.1] - 2025-12-06

--- a/compose-stability-analyzer-idea/build.gradle.kts
+++ b/compose-stability-analyzer-idea/build.gradle.kts
@@ -74,6 +74,7 @@ intellijPlatform {
             <b>0.6.2</b>
             <ul>
                 <li><b>Fixed property source file location and navigation in tool window</b> (Issue #67) - Properties now show correct file name and double-click navigation works</li>
+                <li><b>Improved ignored type pattern handling in tool window</b> (Issue #74) - Ignored parameters display as stable and composable skippability is recalculated accordingly</li>
             </ul>
             <b>0.6.1</b>
             <ul>


### PR DESCRIPTION
Fix ignored patterns was not applied to window tool properly (#74)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ignored parameters now display as stable in the tool window
  * Composable skippability is recalculated after applying ignore patterns
  * Composables with only ignored unstable parameters now correctly show skippable status
  * Enhanced visibility of composable signatures while respecting ignore pattern settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->