### PR TITLE
Save dependencies as a file and figure out the dep relations

### DIFF
--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerCommandLineProcessor.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerCommandLineProcessor.kt
@@ -55,8 +55,8 @@ public class StabilityAnalyzerCommandLineProcessor : CommandLineProcessor {
 
     public val OPTION_PROJECT_DEPENDENCIES: CliOption = CliOption(
       optionName = "projectDependencies",
-      valueDescription = "<module1,module2,...>",
-      description = "Comma-separated list of project module names",
+      valueDescription = "<path>",
+      description = "Path to file containing project module names (one per line)",
       required = false,
     )
   }

--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerIrGenerationExtension.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerIrGenerationExtension.kt
@@ -36,9 +36,20 @@ public class StabilityAnalyzerIrGenerationExtension(
       null
     }
 
-    // Parse project dependencies from comma-separated string
+    // Read project dependencies from file (projectDependencies is now a file path)
     val dependencyModules = if (projectDependencies.isNotEmpty()) {
-      projectDependencies.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+      try {
+        val dependenciesFile = File(projectDependencies)
+        if (dependenciesFile.exists()) {
+          dependenciesFile.readLines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        } else {
+          emptyList()
+        }
+      } catch (e: Exception) {
+        emptyList()
+      }
     } else {
       emptyList()
     }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -154,6 +154,12 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
     return project.provider {
       val projectDependencies = collectProjectDependencies(project)
 
+      // Write project dependencies to a file to avoid empty string issues with SubpluginOption
+      val stabilityDir = project.layout.buildDirectory.dir("stability").get().asFile
+      stabilityDir.mkdirs()
+      val dependenciesFile = java.io.File(stabilityDir, "project-dependencies.txt")
+      dependenciesFile.writeText(projectDependencies.joinToString("\n"))
+
       listOf(
         SubpluginOption(
           key = OPTION_ENABLED,
@@ -161,11 +167,11 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         ),
         SubpluginOption(
           key = OPTION_STABILITY_OUTPUT_DIR,
-          value = project.layout.buildDirectory.dir("stability").get().asFile.absolutePath,
+          value = stabilityDir.absolutePath,
         ),
         SubpluginOption(
           key = OPTION_PROJECT_DEPENDENCIES,
-          value = projectDependencies.joinToString(","),
+          value = dependenciesFile.absolutePath,
         ),
       )
     }


### PR DESCRIPTION
Save dependencies as a file and figure out the dep relations (#87).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Project dependencies CLI option now accepts a file path instead of comma-separated values, with dependencies specified one per line in the file.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->