### PR TITLE
Add quiet check option for the stabilityCheck gradle task

### DIFF
--- a/stability-gradle/api/stability-gradle.api
+++ b/stability-gradle/api/stability-gradle.api
@@ -27,6 +27,7 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityCheckTask :
 	public abstract fun getIgnoredClasses ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoredPackages ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getProjectName ()Lorg/gradle/api/provider/Property;
+	public abstract fun getQuietCheck ()Lorg/gradle/api/provider/Property;
 	public abstract fun getStabilityDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getStabilityInputFile ()Lorg/gradle/api/file/RegularFileProperty;
 }
@@ -50,5 +51,6 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityValidationC
 	public final fun getIgnoredProjects ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getIncludeTests ()Lorg/gradle/api/provider/Property;
 	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
+	public final fun getQuietCheck ()Lorg/gradle/api/provider/Property;
 }
 

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
@@ -140,4 +140,24 @@ public abstract class StabilityValidationConfig @Inject constructor(
    */
   public val failOnStabilityChange: Property<Boolean> =
     objects.property(Boolean::class.javaObjectType).convention(true)
+
+  /**
+   * Whether to suppress success messages from stability checks.
+   * When true, "✅ Stability check passed." messages will be hidden for modules that pass.
+   * Errors and warnings will still be shown.
+   *
+   * This is useful in multi-module projects to reduce log noise when many modules pass checks.
+   * Default: false (success messages shown)
+   *
+   * Example:
+   * ```
+   * composeStabilityAnalyzer {
+   *   stabilityValidation {
+   *     quietCheck.set(true) // Suppress success messages
+   *   }
+   * }
+   * ```
+   */
+  public val quietCheck: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(false)
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -91,6 +91,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
       ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
       failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
+      quietCheck.set(extension.stabilityValidation.quietCheck)
     }
 
     // Make check task depend on stabilityCheck if enabled (only if check task exists)

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityCheckTask.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityCheckTask.kt
@@ -68,6 +68,12 @@ public abstract class StabilityCheckTask : DefaultTask() {
   @get:Input
   public abstract val failOnStabilityChange: Property<Boolean>
 
+  /**
+   * Whether to suppress success messages when checks pass.
+   */
+  @get:Input
+  public abstract val quietCheck: Property<Boolean>
+
   init {
     group = "verification"
     description = "Check composable stability against reference file"
@@ -135,7 +141,10 @@ public abstract class StabilityCheckTask : DefaultTask() {
         logger.lifecycle("✓ Stability check completed with warnings (failOnStabilityChange=false)")
       }
     } else {
-      logger.lifecycle("✅ Stability check passed.")
+      // Only show success message if quietCheck is false
+      if (!quietCheck.get()) {
+        logger.lifecycle("✅ Stability check passed.")
+      }
     }
   }
 


### PR DESCRIPTION
Add a quiet check option for the stabilityCheck Gradle task (#83)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new quiet mode configuration option that suppresses success messages from stability checks. When enabled, error and warning messages remain fully visible, providing cleaner build output while maintaining visibility into any issues detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->