### PR TITLE
Replace internal nj2k.descendantsOfType with stable PsiTreeUtil API

### DIFF
--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
@@ -111,15 +111,6 @@ internal class KtStabilityInferencer(
     // Use fullyExpandedType to get the actual underlying type
     val expandedType = type.fullyExpandedType
 
-    val expandedTypeString = try {
-      expandedType.render(position = org.jetbrains.kotlin.types.Variance.INVARIANT)
-    } catch (_: StackOverflowError) {
-      return KtStability.Runtime(
-        className = "Unknown",
-        reason = "Unable to render type due to complexity",
-      )
-    }
-
     // 1. Nullable types - MUST be checked first to strip nullability
     // Use KaTypeNullability enum for compatibility with Android Studio AI-243
     val nonNullableType = if (expandedType.isMarkedNullable) {
@@ -138,7 +129,6 @@ internal class KtStabilityInferencer(
     // Function types are ALWAYS stable (captured values are checked separately in Compose compiler)
     val isFunctionType = nonNullableType.isFunctionType ||
       nonNullableType.isSuspendFunctionType ||
-      expandedTypeString.containsTopLevelArrow() ||
       originalTypeString.containsTopLevelArrow()
 
     if (isFunctionType) {
@@ -149,11 +139,9 @@ internal class KtStabilityInferencer(
       } || nonNullableType.annotations.any { annotation ->
         annotation.classId?.asSingleFqName()?.asString() ==
           "androidx.compose.runtime.Composable"
-      } || expandedTypeString.contains("@Composable") ||
-        originalTypeString.contains("@Composable")
+      } || originalTypeString.contains("@Composable")
 
       val isSuspend = nonNullableType.isSuspendFunctionType ||
-        expandedTypeString.contains("suspend") ||
         originalTypeString.contains("suspend")
 
       return KtStability.Certain(
@@ -191,11 +179,9 @@ internal class KtStabilityInferencer(
       } || nonNullableType.annotations.any { annotation ->
         annotation.classId?.asSingleFqName()?.asString() ==
           "androidx.compose.runtime.Composable"
-      } || expandedTypeString.contains("@Composable") ||
-        originalTypeString.contains("@Composable")
+      } || originalTypeString.contains("@Composable")
 
       val isSuspend = nonNullableType.isSuspendFunctionType ||
-        expandedTypeString.contains("suspend") ||
         originalTypeString.contains("suspend")
 
       return KtStability.Certain(


### PR DESCRIPTION
Replace internal nj2k.descendantsOfType with stable PsiTreeUtil API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented intelligent caching mechanism for type alias resolution with automatic expiration, reducing repeated lookups and improving IDE responsiveness during analysis.
  * Streamlined structural type analysis by simplifying function-type detection and composability checking logic.
  * Enhanced internal type lookup mechanisms to optimize overall analysis performance and reduce processing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->