### PR TITLE
Revert IDE compatibility to build 261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Heatmap enabled by default in plugin settings
   - Configurable severity thresholds in Settings > Tools > Compose Stability Analyzer
   - New "Heatmap" tab in the Compose Stability Analyzer tool window
-- **Plugin Verifier integration** (PR #118)
-  - Extended IDE compatibility to build 261 (IntelliJ IDEA 2026.1)
-  - Added `runPluginVerifier` task for automated compatibility testing
-
 ### Improved
 - Tool window now has three tabs: Explorer, Cascade, and Heatmap
 - Start/Stop Recomposition Heatmap button moved to tool window title bar for visibility across all tabs

--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -25,9 +25,6 @@ All notable changes to the IntelliJ IDEA plugin will be documented in this file.
   - Heatmap enabled by default in plugin settings
   - New "Heatmap" tab in the tool window with Refresh/Clear toolbar
   - Configurable settings: severity thresholds, auto-start, show-when-stopped, max recent events
-- **Plugin Verifier integration** (PR #118)
-  - Extended IDE compatibility range to build 261 (IntelliJ IDEA 2026.1)
-
 ### Improved
 - Tool window reorganized with three tabs: Explorer, Cascade, and Heatmap
 - Heatmap toggle button moved from Explorer toolbar to tool window title bar for visibility across all tabs

--- a/compose-stability-analyzer-idea/build.gradle.kts
+++ b/compose-stability-analyzer-idea/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     intellijIdeaCommunity("2025.2")
     bundledPlugin("org.jetbrains.kotlin")
     testFramework(org.jetbrains.intellij.platform.gradle.TestFrameworkType.Platform)
-    pluginVerifier()
   }
 
   testImplementation(kotlin("test"))
@@ -55,7 +54,7 @@ intellijPlatform {
   pluginConfiguration {
     ideaVersion {
       sinceBuild = "242"
-      untilBuild = "261.*"
+      untilBuild = "253.*"
     }
 
     description = """
@@ -78,7 +77,7 @@ intellijPlatform {
                 <li><b>New: Heatmap tab</b> in tool window - Shows recomposition event logs with parameter changes when clicking heatmap counts</li>
                 <li><b>New: Cascade tab</b> in tool window - Dedicated panel for cascade analysis results</li>
                 <li>Start/Stop Heatmap button moved to tool window title bar for easy access across all tabs</li>
-                <li>Extended IDE compatibility to build 261 (IntelliJ IDEA 2026.1)</li>
+                <li>Extended IDE compatibility to build 253 (IntelliJ IDEA 2025.3)</li>
                 <li>Heatmap enabled by default in plugin settings</li>
             </ul>
             <b>0.6.7</b>
@@ -187,18 +186,6 @@ intellijPlatform {
 
   }
 
-  pluginVerification {
-    ides {
-      recommended()
-    }
-    // Pre-existing K2 API issues (KaSessionProvider.handleAnalysisException) in 242-251
-    // cause false positives — the plugin gracefully falls back to PSI on older IDEs.
-    // 261 (2026.1 EAP) uses the unified "idea" artifact which the verifier cannot resolve yet.
-    failureLevel = listOf(
-      org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
-      org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
-    )
-  }
 }
 
 tasks {


### PR DESCRIPTION
Revert IDE compatibility to build 261.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reverts**
  * Removed IDE verification integration
  * Reduced IDE compatibility to build 253 (IntelliJ IDEA 2025.3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->