### PR TITLE
Fix inlay text shows unstable in the recomposition live heatmap

### DIFF
--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/heatmap/HeatmapInlayManager.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/heatmap/HeatmapInlayManager.kt
@@ -244,8 +244,12 @@ internal class HeatmapInlayManager(
       val count = data.totalRecompositionCount
       append("$count recomposition")
       if (count != 1) append("s")
-      if (data.unstableParameters.isNotEmpty()) {
-        append("  |  unstable: ${data.unstableParameters.joinToString(", ")}")
+      if (data.changedParameters.isNotEmpty()) {
+        val topChanged = data.changedParameters.entries
+          .sortedByDescending { it.value }
+          .take(3)
+          .joinToString(", ") { it.key }
+        append("  |  changed: $topChanged")
       }
     }
   }


### PR DESCRIPTION
Fix inlay text shows unstable in the recomposition live heatmap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the Compose stability analysis display to show changed parameters instead of unstable parameters in the heatmap view, highlighting the top three changed items with improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->