### PR TITLE
Add missing ignoredpackages for the stability validation checks

### DIFF
--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityCheckTask.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityCheckTask.kt
@@ -151,6 +151,7 @@ public abstract class StabilityCheckTask : DefaultTask() {
     }
 
     val currentStability = parseStabilityFromCompiler(inputFile)
+      .filterIgnored(ignoredPackages.get(), ignoredClasses.get())
     val referenceStability = parseStabilityFile(referenceFile)
 
     val stabilityConfigurationMatchers = stabilityConfigurationFiles.getOrElse(emptyList())
@@ -485,6 +486,19 @@ public abstract class StabilityCheckTask : DefaultTask() {
     }
 
     return entries
+  }
+
+  private fun Map<String, StabilityEntry>.filterIgnored(
+    ignoredPackages: List<String>,
+    ignoredClasses: List<String>,
+  ): Map<String, StabilityEntry> {
+    if (ignoredPackages.isEmpty() && ignoredClasses.isEmpty()) return this
+    return filterValues { entry ->
+      val packageName = entry.qualifiedName.substringBeforeLast('.', "")
+      val className = entry.qualifiedName.substringAfterLast('.')
+      !ignoredPackages.any { packageName.startsWith(it) } &&
+        !ignoredClasses.contains(className)
+    }
   }
 }
 


### PR DESCRIPTION
Add missing `ignoredpackages` for the stability validation checks (#129)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability to exclude specified packages and classes from stability analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->