### PR TITLE
Implement unstable only option for the stabilityValidation gradle task

### DIFF
--- a/stability-gradle/api/stability-gradle.api
+++ b/stability-gradle/api/stability-gradle.api
@@ -46,6 +46,7 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityDumpTask : 
 	public abstract fun getStabilityConfigurationFiles ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getStabilityFileSuffix ()Lorg/gradle/api/provider/Property;
 	public abstract fun getStabilityInputFiles ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getUnstableOnly ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class com/skydoves/compose/stability/gradle/StabilityValidationConfig {
@@ -61,5 +62,6 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityValidationC
 	public final fun getOutputDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getQuietCheck ()Lorg/gradle/api/provider/Property;
 	public final fun getStabilityConfigurationFiles ()Lorg/gradle/api/provider/ListProperty;
+	public final fun getUnstableOnly ()Lorg/gradle/api/provider/Property;
 }
 

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
@@ -183,6 +183,15 @@ public abstract class StabilityValidationConfig @Inject constructor(
     objects.property(Boolean::class.javaObjectType).convention(false)
 
   /**
+   * When true, only unstable composables (not skippable) are included in the baseline file.
+   * This reduces baseline file size in large projects and lets you focus on fixing stability issues.
+   *
+   * Default: false
+   */
+  public val unstableOnly: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(false)
+
+  /**
    * List of paths to stability configuration files.
    *
    * For more information, see this link:

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -97,6 +97,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
       ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
       stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+      unstableOnly.set(extension.stabilityValidation.unstableOnly)
     }
 
     // Register stability check task
@@ -164,6 +165,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
         stabilityFileSuffix.set(variant.name)
         stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+        unstableOnly.set(extension.stabilityValidation.unstableOnly)
       }
 
       // Register stability check task

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityDumpTask.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityDumpTask.kt
@@ -79,6 +79,12 @@ public abstract class StabilityDumpTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.RELATIVE)
   public abstract val stabilityConfigurationFiles: ListProperty<RegularFile>
 
+  /**
+   * When true, only unstable composables (not skippable) are included in the baseline file.
+   */
+  @get:Input
+  public abstract val unstableOnly: Property<Boolean>
+
   init {
     group = "verification"
     description = "Dump composable stability information to stability file"
@@ -117,7 +123,12 @@ public abstract class StabilityDumpTask : DefaultTask() {
       }
 
     val resolved = applyStabilityConfiguration(filtered, stableTypeMatchers)
-    writeStabilityFile(outputFile, resolved)
+    val finalEntries = if (unstableOnly.get()) {
+      resolved.filter { !it.skippable }
+    } else {
+      resolved
+    }
+    writeStabilityFile(outputFile, finalEntries)
 
     logger.lifecycle("Stability file written to: ${outputFile.absolutePath}")
   }


### PR DESCRIPTION
Implement unstable only option for the stabilityValidation gradle task (#128)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to filter baseline output to only include unstable composables. When enabled, baseline files exclude skippable composables. Defaults to disabled to preserve existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->