### PR TITLE
Prepare for release 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.2] - 2026-04-02
+## [0.7.3] - 2026-04-11
 
 ### Added
 - **Stability configuration file support for `stabilityDump`** (Issue #130, PR #105)
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reduces baseline file size in large projects and focuses on stability issues
 - **New composable diff now includes parameter-level stability details** (PR #105)
   - `stabilityCheck` output for new composables shows each parameter's stability status
+- **Internal state change tracking for `@TraceRecomposition`** (Issue #89)
+  - New `traceStates` annotation parameter: `@TraceRecomposition(traceStates = true)`
+  - Tracks `mutableStateOf`, `mutableIntStateOf`, `derivedStateOf` and other Compose state changes
+  - Compiler plugin detects delegated state variables via `IrLocalDelegatedProperty` IR analysis
+  - Logs state changes with `[state]` prefix, parameter changes with `[param]` prefix
+  - Only changed states are logged to reduce noise
 
 ### Fixed
 - **`ignoredPackages` now consistently respected during `stabilityCheck`** (Issue #129)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This is incredibly useful for:
 First, add the plugin to the `[plugins]` section of your `libs.versions.toml` file:
 
 ```toml
-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.7.2" }
+stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.7.3" }
 ```
 
 Then, apply it to your root `build.gradle.kts` with `apply false`:
@@ -234,7 +234,7 @@ It’s **strongly recommended to use the exact same Kotlin version** as this lib
 
 | Stability Analyzer | Kotlin |
 |--------------------|-------------|
-| 0.7.2+             | 2.3.20 |
+| 0.7.3+             | 2.3.20 |
 | 0.6.5~0.7.0        | 2.3.0 |
 | 0.4.0~0.6.4        | 2.2.21 |
 
@@ -257,9 +257,9 @@ That's it. When this composable recomposes, you'll see logs like:
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 D/Recomposition: [Recomposition #2] UserProfile
-D/Recomposition:   └─ user: User changed (User@abc123 → User@def456)
+D/Recomposition:   └─ [param] user: User changed (User@abc123 → User@def456)
 ```
 
 ### Annotation Parameters
@@ -317,7 +317,7 @@ Now logs include the tag:
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile (tag: user-profile)
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 ```
 
 This is also very useful if you want to set a custom logger for `ComposeStabilityAnalyzer`, to distinguish which composable function should be examined like the example below:
@@ -415,7 +415,7 @@ Let's understand what each log tells you:
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 ```
 
 **What this means:**
@@ -431,7 +431,7 @@ This log confirms the composable is working correctly. The parameter is stable a
 
 ```
 D/Recomposition: [Recomposition #2] UserProfile
-D/Recomposition:   └─ user: User changed (User@abc123 → User@def456)
+D/Recomposition:   └─ [param] user: User changed (User@abc123 → User@def456)
 ```
 
 **What this means:**
@@ -445,7 +445,7 @@ This is normal behavior. The parameter changed, so the composable recomposed to 
 
 ```
 D/Recomposition: [Recomposition #1] UserCard (tag: user-card)
-D/Recomposition:   ├─ user: MutableUser unstable (MutableUser@xyz789)
+D/Recomposition:   ├─ [param] user: MutableUser unstable (MutableUser@xyz789)
 D/Recomposition:   └─ Unstable parameters: [user]
 ```
 
@@ -453,9 +453,9 @@ D/Recomposition:   └─ Unstable parameters: [user]
 
 ```
 D/Recomposition: [Recomposition #5] ProductList (tag: products)
-D/Recomposition:   ├─ title: String stable (Products)
-D/Recomposition:   ├─ count: Int changed (4 → 5)
-D/Recomposition:   ├─ items: List<Product> unstable (List@abc)
+D/Recomposition:   ├─ [param] title: String stable (Products)
+D/Recomposition:   ├─ [param] count: Int changed (4 → 5)
+D/Recomposition:   ├─ [param] items: List<Product> unstable (List@abc)
 D/Recomposition:   └─ Unstable parameters: [items]
 ```
 
@@ -492,13 +492,13 @@ fun ProductCard(
 
 ```
 D/Recomposition: [Recomposition #3] ProductCard (tag: product-card)
-D/Recomposition:   ├─ product: Product unstable (Product@abc)
-D/Recomposition:   ├─ onClick: () -> Unit stable (Function@xyz)
+D/Recomposition:   ├─ [param] product: Product unstable (Product@abc)
+D/Recomposition:   ├─ [param] onClick: () -> Unit stable (Function@xyz)
 D/Recomposition:   └─ Unstable parameters: [product]
 
 D/Recomposition: [Recomposition #4] ProductCard (tag: product-card)
-D/Recomposition:   ├─ product: Product unstable (Product@abc)
-D/Recomposition:   ├─ onClick: () -> Unit stable (Function@xyz)
+D/Recomposition:   ├─ [param] product: Product unstable (Product@abc)
+D/Recomposition:   ├─ [param] onClick: () -> Unit stable (Function@xyz)
 D/Recomposition:   └─ Unstable parameters: [product]
 
 ... (logs continue every scroll)
@@ -537,11 +537,46 @@ Run the app again and check Logcat:
 
 ```
 D/Recomposition: [Recomposition #3] ProductCard (tag: product-card)
-D/Recomposition:   ├─ product: Product stable (Product@abc)
-D/Recomposition:   └─ onClick: () -> Unit stable (Function@xyz)
+D/Recomposition:   ├─ [param] product: Product stable (Product@abc)
+D/Recomposition:   └─ [param] onClick: () -> Unit stable (Function@xyz)
 
 (No more excessive recompositions!)
 ```
+
+### Internal State Tracking
+
+By default, `@TraceRecomposition` only tracks **parameter changes**. When a composable recomposes due to internal state changes (`mutableStateOf`, `derivedStateOf`, etc.), the standard logs show nothing because the parameters haven't changed.
+
+Setting `traceStates = true` enables **internal state tracking**:
+
+```kotlin
+@TraceRecomposition(traceStates = true)
+@Composable
+fun CounterScreen(title: String) {
+    var counter by remember { mutableIntStateOf(0) }
+    val doubled by remember { derivedStateOf { counter * 2 } }
+
+    Column {
+        Text("$title: $counter (doubled: $doubled)")
+        Button(onClick = { counter++ }) {
+            Text("Increment")
+        }
+    }
+}
+```
+
+After clicking the button:
+
+```
+D/Recomposition: [Recomposition #2] CounterScreen
+D/Recomposition:   ├─ [param] title: String stable (Counter)
+D/Recomposition:   ├─ [state] counter: Int changed (0 → 1)
+D/Recomposition:   └─ State changes: [counter]
+```
+
+The `[param]` prefix identifies parameter entries, while `[state]` identifies internal state changes. Only states that actually changed are logged. This helps answer the question: "Why is this composable recomposing when parameters haven't changed?"
+
+> **Note**: State tracking detects delegated state properties (`var x by remember { mutableStateOf(...) }`). Non-delegated patterns (`val state = mutableStateOf(...)`) are not tracked in the current version.
 
 ### Best Practices
 

--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
-## [0.7.2] - 2026-04-02
+## [0.7.3] - 2026-04-11
 
 ### Fixed
 - **ADB not found on Windows** (Issue #139)

--- a/compose-stability-analyzer-idea/build.gradle.kts
+++ b/compose-stability-analyzer-idea/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
 }
 
 group = "com.github.skydoves"
-version = "0.7.2"
+version = "0.7.3"
 
 repositories {
   mavenLocal()

--- a/docs/gradle-plugin/getting-started.md
+++ b/docs/gradle-plugin/getting-started.md
@@ -45,7 +45,7 @@ The Compose Stability Analyzer compiler plugin is tightly coupled to the Kotlin 
 
 | Stability Analyzer | Kotlin |
 |--------------------|--------|
-| 0.7.2+             | 2.3.20 |
+| 0.7.3+             | 2.3.20 |
 | 0.6.5 ~ 0.7.0     | 2.3.0  |
 | 0.4.0 ~ 0.6.4     | 2.2.21 |
 

--- a/docs/gradle-plugin/trace-recomposition.md
+++ b/docs/gradle-plugin/trace-recomposition.md
@@ -21,9 +21,9 @@ When this composable recomposes, detailed logs appear in Logcat showing the reco
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 D/Recomposition: [Recomposition #2] UserProfile
-D/Recomposition:   └─ user: User changed (User@abc123 → User@def456)
+D/Recomposition:   └─ [param] user: User changed (User@abc123 → User@def456)
 ```
 
 The first log entry shows the initial composition: the `user` parameter is stable and the log includes its identity hash. The second entry shows a recomposition triggered by the `user` parameter changing to a different instance, with both the old and new identity hashes displayed.
@@ -46,7 +46,7 @@ Logs now include the tag, making it easy to filter in Logcat:
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile (tag: user-profile)
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 ```
 
 Tags are also valuable when using a [custom logger](custom-logger.md), since you can route events differently based on their tag, for example sending only critical flow recompositions (checkout, authentication) to your analytics platform while logging everything else to Logcat during development.
@@ -69,6 +69,47 @@ fun FrequentlyRecomposingScreen() {
 
 A threshold of `3` works well for most composables. For composables in scrolling lists or frequently updating screens where some recomposition is expected, a higher threshold (e.g., `10` or `20`) helps focus on truly excessive recomposition.
 
+### The `traceStates` Parameter
+
+By default, `@TraceRecomposition` only tracks **parameter changes**. When a composable recomposes due to internal state changes (`mutableStateOf`, `derivedStateOf`, etc.), the standard logs show nothing because the parameters haven't changed.
+
+Setting `traceStates = true` enables **internal state tracking**. The compiler plugin detects state variable declarations in your composable and injects tracking code that logs which states changed between recompositions.
+
+```kotlin
+@TraceRecomposition(traceStates = true)
+@Composable
+fun CounterScreen(title: String) {
+    var counter by remember { mutableIntStateOf(0) }
+    val doubled by remember { derivedStateOf { counter * 2 } }
+
+    Column {
+        Text("$title: $counter (doubled: $doubled)")
+        Button(onClick = { counter++ }) {
+            Text("Increment")
+        }
+    }
+}
+```
+
+After clicking the button, the log now shows both parameter and state information:
+
+```
+D/Recomposition: [Recomposition #2] CounterScreen
+D/Recomposition:   ├─ [param] title: String stable (Counter)
+D/Recomposition:   ├─ [state] counter: Int changed (0 → 1)
+D/Recomposition:   └─ State changes: [counter]
+```
+
+The `[param]` prefix identifies parameter tracking entries, while `[state]` identifies internal state changes. Only states that actually changed are logged, reducing noise. The `State changes` summary at the end lists all changed state variable names for quick reference.
+
+!!! note "Supported state patterns"
+
+    State tracking detects delegated state properties: `var x by remember { mutableStateOf(...) }`, `mutableIntStateOf`, `mutableLongStateOf`, `mutableFloatStateOf`, `mutableDoubleStateOf`, and `derivedStateOf`. Non-delegated patterns (`val state = mutableStateOf(...)`) are not tracked in the current version. Use the `by` delegation syntax for full tracking support.
+
+!!! tip "When to use traceStates"
+
+    Use `traceStates = true` when a composable is recomposing but the parameter logs show no changes. This typically means an internal state or `CompositionLocal` is causing the recomposition, and state tracking will reveal which one.
+
 ## Reading the Logs
 
 Understanding the log output is key to diagnosing recomposition issues. Each log entry contains several pieces of information that, together, tell you exactly what happened and why.
@@ -77,7 +118,7 @@ Understanding the log output is key to diagnosing recomposition issues. Each log
 
 ```
 D/Recomposition: [Recomposition #1] UserProfile
-D/Recomposition:   └─ user: User stable (User@abc123)
+D/Recomposition:   └─ [param] user: User stable (User@abc123)
 ```
 
 The `[Recomposition #1]` counter tells you this is the first time this composable instance is recomposing. `user: User` identifies the parameter by name and type. The `stable` label means the Compose compiler considers this parameter stable, so it won't cause unnecessary recompositions. The identity hash `(User@abc123)` lets you track whether the same instance is being passed across recompositions.
@@ -88,7 +129,7 @@ This log confirms the composable is working correctly. A stable parameter on the
 
 ```
 D/Recomposition: [Recomposition #2] UserProfile
-D/Recomposition:   └─ user: User changed (User@abc123 → User@def456)
+D/Recomposition:   └─ [param] user: User changed (User@abc123 → User@def456)
 ```
 
 The `changed` label is the most important signal. It tells you this parameter's value is different from the last composition, which is the **reason** this composable recomposed. The arrow notation `(User@abc123 → User@def456)` shows the old and new identity hashes, confirming the value actually changed.
@@ -99,7 +140,7 @@ This is normal behavior. The parameter changed, so the composable recomposed to 
 
 ```
 D/Recomposition: [Recomposition #1] UserCard (tag: user-card)
-D/Recomposition:   ├─ user: MutableUser unstable (MutableUser@xyz789)
+D/Recomposition:   ├─ [param] user: MutableUser unstable (MutableUser@xyz789)
 D/Recomposition:   └─ Unstable parameters: [user]
 ```
 
@@ -109,9 +150,9 @@ The `unstable` label means the Compose compiler cannot guarantee this parameter 
 
 ```
 D/Recomposition: [Recomposition #5] ProductList (tag: products)
-D/Recomposition:   ├─ title: String stable (Products)
-D/Recomposition:   ├─ count: Int changed (4 → 5)
-D/Recomposition:   ├─ items: List<Product> unstable (List@abc)
+D/Recomposition:   ├─ [param] title: String stable (Products)
+D/Recomposition:   ├─ [param] count: Int changed (4 → 5)
+D/Recomposition:   ├─ [param] items: List<Product> unstable (List@abc)
 D/Recomposition:   └─ Unstable parameters: [items]
 ```
 
@@ -155,8 +196,8 @@ fun ProductCard(product: Product, onClick: () -> Unit) {
 
 ```
 D/Recomposition: [Recomposition #3] ProductCard (tag: product-card)
-D/Recomposition:   ├─ product: Product unstable (Product@abc)
-D/Recomposition:   ├─ onClick: () -> Unit stable (Function@xyz)
+D/Recomposition:   ├─ [param] product: Product unstable (Product@abc)
+D/Recomposition:   ├─ [param] onClick: () -> Unit stable (Function@xyz)
 D/Recomposition:   └─ Unstable parameters: [product]
 ```
 
@@ -176,8 +217,8 @@ data class Product(val name: String, val price: Double)
 
 ```
 D/Recomposition: [Recomposition #3] ProductCard (tag: product-card)
-D/Recomposition:   ├─ product: Product stable (Product@abc)
-D/Recomposition:   └─ onClick: () -> Unit stable (Function@xyz)
+D/Recomposition:   ├─ [param] product: Product stable (Product@abc)
+D/Recomposition:   └─ [param] onClick: () -> Unit stable (Function@xyz)
 ```
 
 The `ProductCard` is now skippable. During scrolling, Compose will skip recomposing cards whose `product` and `onClick` values haven't changed, resulting in noticeably smoother performance.

--- a/docs/version-map.md
+++ b/docs/version-map.md
@@ -6,7 +6,7 @@ It is **strongly recommended to use the exact same Kotlin version** as this libr
 
 | Stability Analyzer | Kotlin |
 |--------------------|--------|
-| 0.7.2+             | 2.3.20 |
+| 0.7.3+             | 2.3.20 |
 | 0.6.5 ~ 0.7.0     | 2.3.0  |
 | 0.4.0 ~ 0.6.4     | 2.2.21 |
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 
 # Maven publishing
 GROUP=com.github.skydoves
-VERSION_NAME=0.7.3-SNAPSHOT
+VERSION_NAME=0.7.3
 
 POM_URL=https://github.com/skydoves/compose-stability-analyzer/
 POM_SCM_URL=https://github.com/skydoves/compose-stability-analyzer/

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -47,7 +47,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     // This version should match the version in gradle.properties
     // Update this when bumping the library version
-    private const val VERSION = "0.7.3-SNAPSHOT"
+    private const val VERSION = "0.7.3"
 
     // Compiler option keys
     private const val OPTION_ENABLED = "enabled"


### PR DESCRIPTION
Prepare for release 0.7.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `traceStates` annotation parameter for @TraceRecomposition, enabling tracking and logging of internal delegated state changes alongside parameter changes, distinguished by [state] and [param] prefixes.

* **Documentation**
  * Updated guides and Logcat output examples to describe state tracking capability and revised logging format.

* **Chores**
  * Released version 0.7.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->