### PR TITLE
Store stability output of Android variants to their own folder

### DIFF
--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -105,6 +105,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       projectName.set(target.name)
       stabilityInputFiles.setFrom(
         target.fileTree(target.layout.buildDirectory.dir("stability")) {
+          include("stability-info.json")
           include("*/stability-info.json")
         },
       )
@@ -123,6 +124,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       projectName.set(target.name)
       stabilityInputFiles.from(
         target.fileTree(target.layout.buildDirectory.dir("stability")) {
+          include("stability-info.json")
           include("*/stability-info.json")
         },
       )

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -75,7 +75,9 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     // Per-task output directory to avoid shared output conflicts with other plugins (Issue #153)
     target.tasks.withType(KotlinCompile::class.java).configureEach {
-      val stabilityDir = target.layout.buildDirectory.dir("stability/$name")
+      val stabilityDir = target.layout.buildDirectory.dir(
+        getKotlinTaskStabilityFolderName(name),
+      )
       outputs.dir(stabilityDir).optional(true)
     }
 
@@ -174,7 +176,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         projectName.set(target.name)
         stabilityInputFiles.setFrom(
           target.layout.buildDirectory.file(
-            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
+            "stability/$variantNameLowerCase/stability-info.json",
           ),
         )
         outputDir.set(extension.stabilityValidation.outputDir)
@@ -193,7 +195,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         projectName.set(target.name)
         stabilityInputFiles.from(
           target.layout.buildDirectory.file(
-            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
+            "stability/$variantNameLowerCase/stability-info.json",
           ),
         )
         stabilityReferenceFiles.from(extension.stabilityValidation.outputDir)
@@ -284,7 +286,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       // Per-compilation output directory to avoid shared output conflicts (Issue #153)
       val compileTaskName = kotlinCompilation.compileTaskProvider.name
       val stabilityDir = project.layout.buildDirectory
-        .dir("stability/$compileTaskName").get().asFile
+        .dir(getKotlinTaskStabilityFolderName(compileTaskName)).get().asFile
       stabilityDir.mkdirs()
       val dependenciesFile = java.io.File(stabilityDir, "project-dependencies.txt")
       dependenciesFile.writeText(projectDependencies.joinToString("\n"))
@@ -517,4 +519,24 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
    */
   private fun getLintProject(project: Project): Project? =
     project.rootProject.findProject(":stability-lint")
+}
+
+private fun getKotlinTaskStabilityFolderName(taskName: String): String {
+  // Clean up the task name a bit to make folder name a bit clearer
+  // compileKotlin => (blank)
+  // compileDebugKotlin => debug
+  // compileDebugAndroidTestKotlin => debugAndroidTest
+  // compileDebugUnitTestKotlinAndroid => debugUnitTestAndroid
+  // compileJvmCommonKotlinMetadata => jvmCommonMetadata
+
+  val subfolder = taskName
+    .removePrefix("compile")
+    .replace("Kotlin", "")
+    .replaceFirstChar { it.lowercase() }
+
+  return if (subfolder.isBlank()) {
+    "stability"
+  } else {
+    "stability/$subfolder"
+  }
 }


### PR DESCRIPTION
### 🎯 Goal

A continuation of the #101

Up until now, every Kotlin task dropped its stability output into `build/stability`. This was problematic with multi-variant runs:

1. If debug and release source sets are different, stability output might be different, but they would overwrite each other
2. If debug and release compile was ran in parallel, two tasks might write to this file simultaneously, corrupting it

PR fixes this by changing plugin to store stability output into `build/stability/$VARIANT` (such as `/build/stability/debug`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved organization of stability analysis output directories for Kotlin tasks, with clearer folder naming conventions and better variant-scoped structure for stability analysis data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->