### PR TITLE
Disable incremental compilation to clear stale caches

### DIFF
--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -78,6 +78,20 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       val stabilityDir = target.layout.buildDirectory.dir("stability/$name")
       outputs.dir(stabilityDir).optional(true)
     }
+
+    // Disable incremental compilation when stability tasks are in the graph (Issue #156)
+    // Kotlin IC may skip recompiling files when dependency changes are binary-compatible,
+    // but stability can still change (e.g., val → var makes a type UNSTABLE).
+    target.gradle.taskGraph.whenReady {
+      val hasStabilityTasks = allTasks.any {
+        it is StabilityDumpTask || it is StabilityCheckTask
+      }
+      if (hasStabilityTasks) {
+        target.tasks.withType(KotlinCompile::class.java).configureEach {
+          incremental = false
+        }
+      }
+    }
   }
 
   private fun registerTasksNonAndroid(target: Project, extension: StabilityAnalyzerExtension) {


### PR DESCRIPTION
Disable incremental compilation to clear stale caches (#156)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Gradle plugin to modify compilation behavior when stability analysis tasks are executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->