### PR TITLE
Add incremental disabling switch

### DIFF
--- a/stability-gradle/api/stability-gradle.api
+++ b/stability-gradle/api/stability-gradle.api
@@ -51,6 +51,7 @@ public abstract class com/skydoves/compose/stability/gradle/StabilityDumpTask : 
 
 public abstract class com/skydoves/compose/stability/gradle/StabilityValidationConfig {
 	public fun <init> (Lorg/gradle/api/file/ProjectLayout;Lorg/gradle/api/model/ObjectFactory;)V
+	public final fun getAllowIncrementalDisabling ()Lorg/gradle/api/provider/Property;
 	public final fun getAllowMissingBaseline ()Lorg/gradle/api/provider/Property;
 	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
 	public final fun getFailOnStabilityChange ()Lorg/gradle/api/provider/Property;

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerExtension.kt
@@ -202,4 +202,15 @@ public abstract class StabilityValidationConfig @Inject constructor(
   public val stabilityConfigurationFiles: ListProperty<RegularFile> = objects
     .listProperty(RegularFile::class.java)
     .convention(emptyList())
+
+  /**
+   * When true, plugin may disable Kotlin's incremental compilation in some cases
+   * to improve accuracy.
+   *
+   * See https://github.com/skydoves/compose-stability-analyzer/issues/156
+   *
+   * Default: true
+   */
+  public val allowIncrementalDisabling: Property<Boolean> =
+    objects.property(Boolean::class.javaObjectType).convention(true)
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -83,12 +83,14 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
     // Kotlin IC may skip recompiling files when dependency changes are binary-compatible,
     // but stability can still change (e.g., val → var makes a type UNSTABLE).
     target.gradle.taskGraph.whenReady {
-      val hasStabilityTasks = allTasks.any {
-        it is StabilityDumpTask || it is StabilityCheckTask
-      }
-      if (hasStabilityTasks) {
-        target.tasks.withType(KotlinCompile::class.java).configureEach {
-          incremental = false
+      if (extension.stabilityValidation.allowIncrementalDisabling.get()) {
+        val hasStabilityTasks = allTasks.any {
+          it is StabilityDumpTask || it is StabilityCheckTask
+        }
+        if (hasStabilityTasks) {
+          target.tasks.withType(KotlinCompile::class.java).configureEach {
+            incremental = false
+          }
         }
       }
     }


### PR DESCRIPTION
### 🎯 Goal

PR adds a switch for the #157.

This allow users to weigh whether they want to disable incremental compilation (which can be a huge performance hit) just to cover some edge cases in stability analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `allowIncrementalDisabling` configuration option to control whether Kotlin incremental compilation is disabled during stability analysis tasks. This setting defaults to enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->