### PR TITLE
Migrate to Kotlin 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-06-04
+
+### Added
+- **`ParameterStability.UNKNOWN`** — a fourth stability value for types whose stability cannot be determined statically (interfaces and non-final classes). Mirrors the Compose 2.4.0 compiler's `Stability.Unknown`.
+
+### Changed
+- **Bumped Kotlin to 2.4.0** (from 2.3.21). The compiler plugin, runtime, Gradle plugin, Lint rules, and IntelliJ plugin all build against Kotlin 2.4.0.
+  - K2 FIR extension registration migrated off the removed IntelliJ `ProjectExtensionDescriptor` mechanism (`KT-83341`); the deprecated `IrPluginContext.referenceClass`/`referenceFunctions` were replaced with the `finderForSource` API.
+- **New `UNKNOWN` stability rule** — **interfaces** and **non-final (`open`/`abstract`) classes** now report `UNKNOWN` instead of `RUNTIME`/`UNSTABLE`, matching the Compose 2.4.0 compiler. This includes any `kotlin.Any?` parameter (since `Any` is `open`). Skippability is unchanged (these types were already non-skippable), but the rule **will produce diffs in committed `.stability` baselines** — run `./gradlew stabilityDump` to refresh them. A `STABLE → UNKNOWN` transition is reported as a regression by `stabilityCheck`.
+
 ## [0.8.0] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ This is incredibly useful for:
 First, add the plugin to the `[plugins]` section of your `libs.versions.toml` file:
 
 ```toml
-stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.8.0" }
+stability-analyzer = { id = "com.github.skydoves.compose.stability.analyzer", version = "0.9.0" }
 ```
 
 Then, apply it to your root `build.gradle.kts` with `apply false`:
@@ -284,6 +284,7 @@ It’s **strongly recommended to use the exact same Kotlin version** as this lib
 
 | Stability Analyzer | Kotlin |
 |--------------------|-------------|
+| 0.9.0              | 2.4.0 |
 | 0.8.0              | 2.3.21 |
 | 0.7.5              | 2.3.21 |
 | 0.7.4              | 2.3.20 |
@@ -722,7 +723,23 @@ public fun com.example.UnstableCard(user: com.example.MutableUser): kotlin.Unit
   restartable: true
   params:
     - user: UNSTABLE (has mutable properties)
+
+@Composable
+public fun com.example.DetailScreen(repository: com.example.UserRepository): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - repository: UNKNOWN (interface or non-final class; concrete implementation unknown)
 ```
+
+Each parameter is reported with one of four stability values, matching the Compose compiler:
+
+| Value | Meaning |
+|-------|---------|
+| `STABLE` | Known stable at compile time (skippable). |
+| `UNSTABLE` | Known unstable (e.g. has mutable `var` properties). |
+| `RUNTIME` | Stability depends on a runtime value (e.g. generic type parameters, standard collections). |
+| `UNKNOWN` | Cannot be determined statically because the concrete type is unknown — an **interface** or a **non-final (open/abstract) class**. Mirrors Compose 2.4.0, which infers `Unknown` for these by default. Like `RUNTIME`/`UNSTABLE`, a parameter with this value does not make a composable statically skippable. In `stabilityCheck`, a `STABLE → UNKNOWN` transition is reported as a regression. |
 
 This file is your **stability contract**. It says "these are all my composables, and this is how stable they should be."
 

--- a/app/stability/app-debug.stability
+++ b/app/stability/app-debug.stability
@@ -78,7 +78,7 @@ public fun com.skydoves.myapplication.Icon(title: kotlin.String, painter: androi
   restartable: true
   params:
     - title: STABLE (String is immutable)
-    - painter: RUNTIME (requires runtime check)
+    - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - users: RUNTIME (requires runtime check)
     - normalSealedClass: STABLE (class with no mutable properties)
     - stableSealedClass: STABLE (class with no mutable properties)
@@ -125,6 +125,28 @@ public fun com.skydoves.myapplication.MyComposable(uiResult: com.skydoves.myappl
     - uiResult: RUNTIME (requires runtime check)
     - uiResult2: RUNTIME (requires runtime check)
     - uiResult4: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.skydoves.myapplication.RealityCheckExample(tick: kotlin.Int): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - tick: STABLE (primitive type)
+
+@Composable
+public fun com.skydoves.myapplication.RealityFalseAlarmCard(user: com.skydoves.myapplication.models.UnstableUser, tick: kotlin.Int): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - user: UNSTABLE (has mutable properties or unstable members)
+    - tick: STABLE (primitive type)
+
+@Composable
+public fun com.skydoves.myapplication.RealitySilentWasteCard(user: com.skydoves.myapplication.models.UnstableUser): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - user: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 public fun com.skydoves.myapplication.RecompositionDemo(): kotlin.Unit
@@ -188,7 +210,7 @@ public fun com.skydoves.myapplication.Test4(count: androidx.lifecycle.ViewModel)
   skippable: false
   restartable: true
   params:
-    - count: RUNTIME (requires runtime check)
+    - count: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.myapplication.Test6(count: kotlin.collections.Set<kotlin.String>): kotlin.Unit

--- a/app/stability/app-release.stability
+++ b/app/stability/app-release.stability
@@ -78,7 +78,7 @@ public fun com.skydoves.myapplication.Icon(title: kotlin.String, painter: androi
   restartable: true
   params:
     - title: STABLE (String is immutable)
-    - painter: RUNTIME (requires runtime check)
+    - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - users: RUNTIME (requires runtime check)
     - normalSealedClass: STABLE (class with no mutable properties)
     - stableSealedClass: STABLE (class with no mutable properties)
@@ -125,6 +125,28 @@ public fun com.skydoves.myapplication.MyComposable(uiResult: com.skydoves.myappl
     - uiResult: RUNTIME (requires runtime check)
     - uiResult2: RUNTIME (requires runtime check)
     - uiResult4: RUNTIME (requires runtime check)
+
+@Composable
+public fun com.skydoves.myapplication.RealityCheckExample(tick: kotlin.Int): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - tick: STABLE (primitive type)
+
+@Composable
+public fun com.skydoves.myapplication.RealityFalseAlarmCard(user: com.skydoves.myapplication.models.UnstableUser, tick: kotlin.Int): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - user: UNSTABLE (has mutable properties or unstable members)
+    - tick: STABLE (primitive type)
+
+@Composable
+public fun com.skydoves.myapplication.RealitySilentWasteCard(user: com.skydoves.myapplication.models.UnstableUser): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - user: UNSTABLE (has mutable properties or unstable members)
 
 @Composable
 public fun com.skydoves.myapplication.RecompositionDemo(): kotlin.Unit
@@ -188,7 +210,7 @@ public fun com.skydoves.myapplication.Test4(count: androidx.lifecycle.ViewModel)
   skippable: false
   restartable: true
   params:
-    - count: RUNTIME (requires runtime check)
+    - count: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.myapplication.Test6(count: kotlin.collections.Set<kotlin.String>): kotlin.Unit

--- a/compiler-tests/build.gradle.kts
+++ b/compiler-tests/build.gradle.kts
@@ -111,6 +111,11 @@ tasks.withType<Test> {
   systemProperty("idea.ignore.disabled.plugins", "true")
   systemProperty("idea.home.path", rootDir.absolutePath)
 
+  // Regenerate golden FIR/IR dump files: ./gradlew :compiler-tests:test -Pupdate.test.data
+  if (project.hasProperty("update.test.data")) {
+    systemProperty("kotlin.test.update.test.data", "true")
+  }
+
   // Larger memory for tests
   minHeapSize = "512m"
   maxHeapSize = "2g"

--- a/compiler-tests/src/test/data/dump/fir/TraceRecompositionAnnotation.fir.txt
+++ b/compiler-tests/src/test/data/dump/fir/TraceRecompositionAnnotation.fir.txt
@@ -17,6 +17,6 @@ FILE: TraceRecompositionAnnotation.kt
         public final fun copy(name: R|kotlin/String| = this@R|/User|.R|/User.name|, age: R|kotlin/Int| = this@R|/User|.R|/User.age|): R|User|
 
     }
-    @R|com/skydoves/compose/stability/runtime/TraceRecomposition|(tag = String(profile), threshold = Int(3)) public final fun UserProfile(user: R|User|): R|kotlin/Unit| {
+    @R|com/skydoves/compose/stability/runtime/TraceRecomposition|(tag = String(profile) [evaluated = String(profile)], threshold = Int(3) [evaluated = Int(3)]) public final fun UserProfile(user: R|User|): R|kotlin/Unit| {
         R|kotlin/io/println|(<strcat>(String(User: ), R|<local>/user|.R|/User.name|, String(, Age: ), R|<local>/user|.R|/User.age|))
     }

--- a/compiler-tests/src/test/kotlin/com/skydoves/compose/stability/compiler/tests/ClasspathBasedStandardLibrariesPathProvider.kt
+++ b/compiler-tests/src/test/kotlin/com/skydoves/compose/stability/compiler/tests/ClasspathBasedStandardLibrariesPathProvider.kt
@@ -15,6 +15,7 @@
  */
 package com.skydoves.compose.stability.compiler.tests
 
+import org.jetbrains.kotlin.platform.wasm.WasmTarget
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 import java.io.File
 
@@ -76,6 +77,10 @@ object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPath
   override fun defaultJsStdlib(): File = getFile("kotlin-stdlib-js")
 
   override fun kotlinTestJsKLib(): File = getFile("kotlin-test-js")
+
+  override fun fullWasmStdlib(target: WasmTarget): File = TODO("Not needed for JVM-only tests")
+
+  override fun kotlinTestWasmKLib(target: WasmTarget): File = TODO("Not needed for JVM-only tests")
 
   override fun scriptingPluginFilesForTests(): Collection<File> {
     TODO("Not needed for JVM-only tests")

--- a/compiler-tests/src/test/kotlin/com/skydoves/compose/stability/compiler/tests/StabilityTestConfigurator.kt
+++ b/compiler-tests/src/test/kotlin/com/skydoves/compose/stability/compiler/tests/StabilityTestConfigurator.kt
@@ -20,8 +20,9 @@ import com.skydoves.compose.stability.compiler.StabilityAnalyzerIrGenerationExte
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.compiler.plugin.registerExtension
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.EnvironmentConfigurator
 import org.jetbrains.kotlin.test.services.TestServices
@@ -40,8 +41,9 @@ class StabilityTestConfigurator(testServices: TestServices) :
     module: TestModule,
     configuration: CompilerConfiguration,
   ) {
-    // Register FIR extensions for frontend analysis (K2)
-    FirExtensionRegistrarAdapter.registerExtension(
+    // Register FIR extensions for frontend analysis (K2). Matches the production registrar's
+    // Kotlin 2.4.0 registration (KT-83341): register via FirExtensionRegistrar, not the adapter.
+    FirExtensionRegistrar.registerExtension(
       StabilityAnalyzerFirExtensionRegistrar(),
     )
 

--- a/compose-stability-analyzer-idea/CHANGELOG.md
+++ b/compose-stability-analyzer-idea/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the IntelliJ IDEA plugin will be documented in this file.
 
+## [0.9.0] - 2026-06-04
+
+### Changed
+- **Updated to Kotlin 2.4.0.**
+- **New `UNKNOWN` stability** — **interfaces** and **non-final (`open`/`abstract`) classes** (including `Any?`) now show as **Unknown** instead of Runtime/Unstable, matching the Compose 2.4.0 compiler. Surfaced in gutter icons, hover tooltips, inline hints, and the Reality Check. Skippability is unchanged.
+
 ## [0.8.0] - 2026-05-29
 
 ### Added

--- a/compose-stability-analyzer-idea/build.gradle.kts
+++ b/compose-stability-analyzer-idea/build.gradle.kts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 plugins {
-  // Pinned to Kotlin 2.3.0 — the K2 Analysis API from IntelliJ 2025.2 uses context receivers,
-  // which are removed in Kotlin 2.3.20. This module is built separately from the main project.
-  kotlin("jvm") version "2.3.0"
+  // Built with Kotlin 2.4.0 to match the main project. Context receivers (removed in 2.3.20)
+  // were migrated to context parameters. This module is built separately from the main project.
+  kotlin("jvm") version "2.4.0"
   id("org.jetbrains.intellij.platform") version "2.10.1"
   id("com.diffplug.spotless") version "6.21.0"
 }
@@ -26,7 +26,7 @@ kotlin {
 }
 
 group = "com.github.skydoves"
-version = "0.8.0"
+version = "0.9.0"
 
 repositories {
   mavenLocal()
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.skydoves:compose-stability-runtime-jvm:0.8.0")
+  implementation("com.github.skydoves:compose-stability-runtime-jvm:0.9.0")
 
   intellijPlatform {
     intellijIdeaCommunity("2025.2")
@@ -74,6 +74,11 @@ intellijPlatform {
             </ul>
         """.trimIndent()
     changeNotes = """
+            <b>0.9.0</b>
+            <ul>
+                <li><b>Updated to Kotlin 2.4.0.</b></li>
+                <li><b>New UNKNOWN stability</b> - interfaces and non-final (open/abstract) classes, including <code>Any?</code>, now report as Unknown instead of Runtime/Unstable, matching the Compose 2.4.0 compiler. Shown in gutter icons, tooltips, inline hints, and the Reality Check (skippability is unchanged).</li>
+            </ul>
             <b>0.8.0</b>
             <ul>
                 <li><b>New: Stability Reality Check</b> - Reconciles the compiler's static stability prediction with live runtime recomposition data and grades each parameter as confirmed / false alarm / silent waste / justified. Shown in editor inlays, hover tooltips (predicted vs. actual), and a new Reality tool-window tab with a wasted-recomposition tally.</li>
@@ -220,7 +225,6 @@ tasks {
       jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
       freeCompilerArgs.addAll(
         listOf(
-          "-Xcontext-receivers",
           "-opt-in=org.jetbrains.kotlin.analysis.api.KaExperimentalApi",
           "-opt-in=org.jetbrains.kotlin.analysis.api.KaImplementationDetail",
         ),

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnalyzer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnalyzer.kt
@@ -619,11 +619,24 @@ internal object StabilityAnalyzer {
               }
             }
 
-            // 6. If it's an interface, return RUNTIME (cannot determine)
+            // 6. Interfaces - concrete implementation unknown (Compose 2.4.0: Unknown)
             if (resolved.isInterface()) {
               return StabilityResult(
-                ParameterStability.RUNTIME,
+                ParameterStability.UNKNOWN,
                 "Interface type - actual implementation could be mutable",
+              )
+            }
+
+            // 6b. Non-final (abstract/open) classes - concrete subtype unknown
+            // (Compose 2.4.0: Unknown). @Stable/@Immutable classes are handled above;
+            // sealed classes use the `sealed` (not `abstract`/`open`) modifier, so they fall
+            // through to property analysis.
+            if (resolved.hasModifier(org.jetbrains.kotlin.lexer.KtTokens.ABSTRACT_KEYWORD) ||
+              resolved.hasModifier(org.jetbrains.kotlin.lexer.KtTokens.OPEN_KEYWORD)
+            ) {
+              return StabilityResult(
+                ParameterStability.UNKNOWN,
+                "Non-final class - actual implementation could be mutable",
               )
             }
 

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnnotator.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnnotator.kt
@@ -80,7 +80,7 @@ public class StabilityAnnotator : Annotator {
         }
       }
 
-      ParameterStability.RUNTIME -> {
+      ParameterStability.RUNTIME, ParameterStability.UNKNOWN -> {
         element.nameIdentifier?.let { nameElement ->
           holder.newAnnotation(
             HighlightSeverity.WEAK_WARNING,

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityDocumentationProvider.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityDocumentationProvider.kt
@@ -143,7 +143,7 @@ public class StabilityDocumentationProvider : AbstractDocumentationProvider() {
             ParameterStability.UNSTABLE ->
               "<span style='color: ${StabilityConstants.Colors.UNSTABLE_HTML};'>❌</span>"
 
-            ParameterStability.RUNTIME ->
+            ParameterStability.RUNTIME, ParameterStability.UNKNOWN ->
               "<span style='color: ${StabilityConstants.Colors.RUNTIME_HTML};'>⚠️</span>"
           }
           append(icon)
@@ -198,7 +198,7 @@ public class StabilityDocumentationProvider : AbstractDocumentationProvider() {
             ParameterStability.UNSTABLE ->
               "<span style='color: ${StabilityConstants.Colors.UNSTABLE_HTML};'>❌</span>"
 
-            ParameterStability.RUNTIME ->
+            ParameterStability.RUNTIME, ParameterStability.UNKNOWN ->
               "<span style='color: ${StabilityConstants.Colors.RUNTIME_HTML};'>⚠️</span>"
           }
           append(icon)

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityInlayHintsProvider.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityInlayHintsProvider.kt
@@ -139,7 +139,7 @@ public class StabilityInlayHintsProvider :
           ParameterStability.UNSTABLE ->
             StabilityConstants.Labels.UNSTABLE to Color(globalSettings.unstableHintColorRGB)
 
-          ParameterStability.RUNTIME ->
+          ParameterStability.RUNTIME, ParameterStability.UNKNOWN ->
             StabilityConstants.Labels.RUNTIME to Color(globalSettings.runtimeHintColorRGB)
         }
 

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityLineMarkerProvider.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityLineMarkerProvider.kt
@@ -109,7 +109,9 @@ public class StabilityLineMarkerProvider : LineMarkerProvider {
     }
 
     val hasUnstable = allParams.any { it.stability == ParameterStability.UNSTABLE }
-    val hasRuntime = allParams.any { it.stability == ParameterStability.RUNTIME }
+    val hasRuntime = allParams.any {
+      it.stability == ParameterStability.RUNTIME || it.stability == ParameterStability.UNKNOWN
+    }
     val allStable = allParams.all { it.stability == ParameterStability.STABLE }
 
     val color = when {
@@ -134,7 +136,9 @@ public class StabilityLineMarkerProvider : LineMarkerProvider {
     return buildString {
       val stableCount = analysis.parameters.count { it.stability == ParameterStability.STABLE }
       val unstableCount = analysis.parameters.count { it.stability == ParameterStability.UNSTABLE }
-      val runtimeCount = analysis.parameters.count { it.stability == ParameterStability.RUNTIME }
+      val runtimeCount = analysis.parameters.count {
+        it.stability == ParameterStability.RUNTIME || it.stability == ParameterStability.UNKNOWN
+      }
       val totalCount = analysis.parameters.size
 
       // Check if all non-stable parameters are runtime
@@ -186,7 +190,10 @@ public class StabilityLineMarkerProvider : LineMarkerProvider {
         append("Runtime: ")
         append(
           analysis.parameters
-            .filter { it.stability == ParameterStability.RUNTIME }
+            .filter {
+              it.stability == ParameterStability.RUNTIME ||
+                it.stability == ParameterStability.UNKNOWN
+            }
             .joinToString(", ") { it.name },
         )
       }
@@ -210,7 +217,7 @@ public class StabilityLineMarkerProvider : LineMarkerProvider {
         it.stability == ParameterStability.UNSTABLE
       }
       val runtimeReceiverCount = analysis.receivers.count {
-        it.stability == ParameterStability.RUNTIME
+        it.stability == ParameterStability.RUNTIME || it.stability == ParameterStability.UNKNOWN
       }
       val totalReceiverCount = analysis.receivers.size
 

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/cascade/CascadeCellRenderer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/cascade/CascadeCellRenderer.kt
@@ -85,7 +85,9 @@ internal class CascadeCellRenderer : ColoredTreeCellRenderer() {
     val info = data.node.stabilityInfo
     val isSkippable = info.isSkippable
     val hasUnstable = info.parameters.any { it.stability == ParameterStability.UNSTABLE }
-    val hasRuntime = info.parameters.any { it.stability == ParameterStability.RUNTIME }
+    val hasRuntime = info.parameters.any {
+      it.stability == ParameterStability.RUNTIME || it.stability == ParameterStability.UNKNOWN
+    }
     val isRuntimeOnly = !isSkippable && !hasUnstable && hasRuntime
 
     icon = AllIcons.Nodes.Function
@@ -101,7 +103,9 @@ internal class CascadeCellRenderer : ColoredTreeCellRenderer() {
 
     // Show non-stable parameter count
     val unstableCount = info.parameters.count { it.stability == ParameterStability.UNSTABLE }
-    val runtimeCount = info.parameters.count { it.stability == ParameterStability.RUNTIME }
+    val runtimeCount = info.parameters.count {
+      it.stability == ParameterStability.RUNTIME || it.stability == ParameterStability.UNKNOWN
+    }
     if (unstableCount > 0) {
       append(
         " ($unstableCount unstable)",

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStability.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStability.kt
@@ -93,7 +93,7 @@ internal sealed class KtStability {
     return when (this) {
       is Certain -> if (stable) ParameterStability.STABLE else ParameterStability.UNSTABLE
       is Runtime -> ParameterStability.RUNTIME
-      is Unknown -> ParameterStability.RUNTIME
+      is Unknown -> ParameterStability.UNKNOWN
       is Parameter -> ParameterStability.RUNTIME
       is Combined -> {
         val stabilities = elements.map { it.toParameterStability() }

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/KtStabilityInferencer.kt
@@ -75,8 +75,7 @@ internal class KtStabilityInferencer(
    * Analyzes a Kotlin type to determine its stability.
    * Main entry point for K2-based stability analysis.
    */
-  context(KaSession)
-  internal fun ktStabilityOf(type: KaType): KtStability {
+  internal fun KaSession.ktStabilityOf(type: KaType): KtStability {
     val originalTypeString = try {
       type.render(position = org.jetbrains.kotlin.types.Variance.INVARIANT)
     } catch (e: StackOverflowError) {
@@ -105,8 +104,7 @@ internal class KtStabilityInferencer(
   /**
    * Internal implementation separated for proper cleanup.
    */
-  context(KaSession)
-  private fun ktStabilityOfInternal(type: KaType, originalTypeString: String): KtStability {
+  private fun KaSession.ktStabilityOfInternal(type: KaType, originalTypeString: String): KtStability {
     // 0. Expand typealiases first - resolve typealias to actual type
     // Use fullyExpandedType to get the actual underlying type
     val expandedType = type.fullyExpandedType
@@ -223,8 +221,12 @@ internal class KtStabilityInferencer(
       )
     }
 
-    // If class stability is runtime but all type args are stable, still runtime
-    if (classStability is KtStability.Runtime) {
+    // If the class itself is not definitively stable (Runtime / Unknown / type Parameter /
+    // Combined), stable type arguments must NOT promote it to stable. Keep the class's own
+    // stability — e.g. a generic interface `Repo<String>` stays UNKNOWN even though String is
+    // stable. (Pre-2.4.0 this only guarded Runtime; interfaces were Runtime, so it worked. Now
+    // interfaces are Unknown, so the guard must cover every non-Certain case.)
+    if (classStability !is KtStability.Certain) {
       return classStability
     }
 
@@ -245,8 +247,7 @@ internal class KtStabilityInferencer(
    * Analyzes type arguments of a generic type.
    * Returns empty list if type has no type arguments.
    */
-  context(KaSession)
-  private fun analyzeTypeArguments(type: KaType): List<KtStability> {
+  private fun KaSession.analyzeTypeArguments(type: KaType): List<KtStability> {
     return try {
       // Use reflection to access typeArguments as it may differ between K2 versions
       val typeArgsMethod = type::class.members.find { it.name == "typeArguments" }
@@ -276,8 +277,7 @@ internal class KtStabilityInferencer(
    * @param declaration the class symbol to analyze
    * @param currentlyAnalyzing set of symbols being analyzed (prevents infinite recursion)
    */
-  context(KaSession)
-  private fun analyzeClassSymbol(
+  private fun KaSession.analyzeClassSymbol(
     declaration: KaClassLikeSymbol,
     currentlyAnalyzing: Set<KaClassLikeSymbol>,
   ): KtStability {
@@ -330,7 +330,7 @@ internal class KtStabilityInferencer(
     }
 
     // 7. Check for @Stable or @Immutable annotations
-    if (classSymbol.hasStableAnnotation()) {
+    if (hasStableAnnotation(classSymbol)) {
       return KtStability.Certain(
         stable = true,
         reason = StabilityConstants.Messages.STABLE_ANNOTATION,
@@ -407,7 +407,7 @@ internal class KtStabilityInferencer(
     }
 
     // 15. Value classes (inline classes) - stability depends on underlying type
-    if (classSymbol.isInlineClass()) {
+    if (isInlineClass(classSymbol)) {
       return analyzeValueClass(classSymbol, currentlyAnalyzing)
     }
 
@@ -447,43 +447,50 @@ internal class KtStabilityInferencer(
       }
     }
 
-    // 18. Interfaces - cannot determine (RUNTIME)
+    // 18. Interfaces - concrete implementation unknown (Compose 2.4.0: Unknown)
     if (classSymbol.classKind == KaClassKind.INTERFACE) {
-      return KtStability.Runtime(
-        className = fqName ?: simpleName,
-        reason = "Interface type - actual implementation could be mutable",
-      )
+      return KtStability.Unknown(fqName ?: simpleName)
     }
 
-    // 19. Abstract classes - cannot determine (RUNTIME)
+    // 19. Abstract classes - concrete implementation unknown (Compose 2.4.0: Unknown)
     // EXCEPT: Sealed classes with @Stable/@Immutable should be analyzed like regular classes
     // Issue #31: Sealed classes with @Immutable/@Stable should propagate stability to subclasses
     if (classSymbol.modality == KaSymbolModality.ABSTRACT) {
       // Check if this abstract class has @Stable or @Immutable annotation
-      // If it does, it should be analyzed (not immediately returned as RUNTIME)
+      // If it does, it should be analyzed (not immediately returned as Unknown)
       val hasStabilityAnnotation = classSymbol.annotations.any { annotation ->
         val annotationFqName = annotation.classId?.asSingleFqName()?.asString()
         annotationFqName == "androidx.compose.runtime.Stable" ||
           annotationFqName == "androidx.compose.runtime.Immutable"
       }
 
-      // Only return RUNTIME if it doesn't have stability annotations
+      // Only return Unknown if it doesn't have stability annotations
       if (!hasStabilityAnnotation) {
-        return KtStability.Runtime(
-          className = fqName ?: simpleName,
-          reason = "Abstract class - actual implementation could be mutable",
-        )
+        return KtStability.Unknown(fqName ?: simpleName)
       }
       // Abstract classes with @Stable/@Immutable continue to property analysis
+    }
+
+    // 19a. Non-final (open) classes - concrete subtype unknown (Compose 2.4.0: Unknown)
+    //      EXCEPT: classes explicitly trusted via @Stable/@Immutable.
+    if (classSymbol.modality == KaSymbolModality.OPEN) {
+      val hasStabilityAnnotation = classSymbol.annotations.any { annotation ->
+        val annotationFqName = annotation.classId?.asSingleFqName()?.asString()
+        annotationFqName == "androidx.compose.runtime.Stable" ||
+          annotationFqName == "androidx.compose.runtime.Immutable"
+      }
+      if (!hasStabilityAnnotation) {
+        return KtStability.Unknown(fqName ?: simpleName)
+      }
     }
 
     // 19b. Cross-module types without @Stable/@Immutable/@StabilityInferred are UNSTABLE
     // Classes from other modules must be explicitly annotated to be considered stable
     // This prevents assuming stability for classes where we can't see the implementation
     // IMPORTANT: This check comes AFTER all built-in stable types (primitives, String, etc.)
-    if (classSymbol.isFromDifferentModule()) {
+    if (isFromDifferentModule(classSymbol)) {
       // Check if it has @StabilityInferred annotation
-      val stabilityInferredParams = classSymbol.getStabilityInferredParameters()
+      val stabilityInferredParams = getStabilityInferredParameters(classSymbol)
       if (stabilityInferredParams == null) {
         // No @Stable, @Immutable, or @StabilityInferred annotation
         return KtStability.Certain(
@@ -507,7 +514,7 @@ internal class KtStabilityInferencer(
       propertyStability is KtStability.Certain -> propertyStability
       else -> {
         // 20. Check @StabilityInferred: parameters=0 means stable, else runtime
-        val stabilityInferredParams = classSymbol.getStabilityInferredParameters()
+        val stabilityInferredParams = getStabilityInferredParameters(classSymbol)
         when {
           stabilityInferredParams != null -> {
             if (stabilityInferredParams == 0) {
@@ -532,8 +539,7 @@ internal class KtStabilityInferencer(
   /**
    * Analyzes all properties of a class to determine overall stability.
    */
-  context(KaSession)
-  private fun analyzeClassProperties(
+  private fun KaSession.analyzeClassProperties(
     classSymbol: KaClassSymbol,
     currentlyAnalyzing: Set<KaClassLikeSymbol>,
   ): KtStability {
@@ -647,8 +653,7 @@ internal class KtStabilityInferencer(
    * Analyzes superclass stability.
    * Returns the stability of the superclass, or null if no superclass or superclass is stable.
    */
-  context(KaSession)
-  private fun analyzeSuperclassStability(
+  private fun KaSession.analyzeSuperclassStability(
     classSymbol: KaClassSymbol,
     currentlyAnalyzing: Set<KaClassLikeSymbol>,
   ): KtStability? {
@@ -698,8 +703,7 @@ internal class KtStabilityInferencer(
    * Analyzes a value class to determine its stability.
    * Value classes inherit the stability of their underlying type.
    */
-  context(KaSession)
-  private fun analyzeValueClass(
+  private fun KaSession.analyzeValueClass(
     classSymbol: KaClassSymbol,
     currentlyAnalyzing: Set<KaClassLikeSymbol>,
   ): KtStability {
@@ -737,9 +741,8 @@ internal class KtStabilityInferencer(
   /**
    * Check if a class has @Stable or @Immutable annotation.
    */
-  context(KaSession)
-  private fun KaClassSymbol.hasStableAnnotation(): Boolean {
-    return annotations.any { annotation ->
+  private fun KaSession.hasStableAnnotation(symbol: KaClassSymbol): Boolean {
+    return symbol.annotations.any { annotation ->
       val fqName = annotation.classId?.asSingleFqName()?.asString()
       fqName == StabilityConstants.Annotations.STABLE_FQ ||
         fqName == StabilityConstants.Annotations.IMMUTABLE_FQ ||
@@ -760,10 +763,9 @@ internal class KtStabilityInferencer(
    * This is crucial for cross-module stability: classes from other modules should be
    * UNSTABLE unless annotated with @Stable/@Immutable or @StabilityInferred(parameters=0).
    */
-  context(KaSession)
-  private fun KaClassSymbol.getStabilityInferredParameters(): Int? {
+  private fun KaSession.getStabilityInferredParameters(symbol: KaClassSymbol): Int? {
     val stabilityInferredFqName = "androidx.compose.runtime.internal.StabilityInferred"
-    val annotation = annotations.firstOrNull { annotation ->
+    val annotation = symbol.annotations.firstOrNull { annotation ->
       annotation.classId?.asSingleFqName()?.asString() == stabilityInferredFqName
     } ?: return null
 
@@ -822,10 +824,9 @@ internal class KtStabilityInferencer(
   /**
    * Check if a class is a value class (inline class).
    */
-  context(KaSession)
-  private fun KaClassSymbol.isInlineClass(): Boolean {
+  private fun KaSession.isInlineClass(symbol: KaClassSymbol): Boolean {
     // Check for @JvmInline annotation (modern value classes)
-    return annotations.any { annotation ->
+    return symbol.annotations.any { annotation ->
       annotation.classId?.asSingleFqName()?.asString() == "kotlin.jvm.JvmInline"
     }
   }
@@ -834,11 +835,10 @@ internal class KtStabilityInferencer(
    * Checks if a class is from a different module or external library.
    * Detects: (1) External JARs/AARs via origins, (2) Other modules via module comparison.
    */
-  context(KaSession)
-  private fun KaClassSymbol.isFromDifferentModule(): Boolean {
+  private fun KaSession.isFromDifferentModule(symbol: KaClassSymbol): Boolean {
     return try {
       // Check 1: External library classes (compiled JARs/AARs)
-      val origin = origin
+      val origin = symbol.origin
       val originName = origin.toString()
       val isFromLibrary = originName.contains("LIBRARY") && !originName.contains("SOURCE")
 
@@ -847,7 +847,7 @@ internal class KtStabilityInferencer(
       }
 
       // Check 2: Classes from other project modules
-      val classFile = psi?.containingFile?.virtualFile
+      val classFile = symbol.psi?.containingFile?.virtualFile
       if (classFile != null && project != null && usageSiteModule != null) {
         val classModule = ProjectFileIndex.getInstance(project).getModuleForFile(
           classFile,

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/StabilityAnalyzerK2.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/k2/StabilityAnalyzerK2.kt
@@ -69,8 +69,7 @@ internal object StabilityAnalyzerK2 {
   /**
    * Performs K2-based analysis within a KaSession context.
    */
-  context(KaSession)
-  private fun analyzeWithK2Session(function: KtNamedFunction): ComposableStabilityInfo {
+  private fun KaSession.analyzeWithK2Session(function: KtNamedFunction): ComposableStabilityInfo {
     // Get function symbol
     val functionSymbol = function.symbol
 
@@ -103,7 +102,7 @@ internal object StabilityAnalyzerK2 {
     // Analyze value parameters
     val parameters = functionSymbol.valueParameters.map { param ->
       val paramType = param.returnType
-      val stability = inferencer.ktStabilityOf(paramType)
+      val stability = with(inferencer) { ktStabilityOf(paramType) }
 
       ParameterStabilityInfo(
         name = param.name.asString(),
@@ -150,8 +149,7 @@ internal object StabilityAnalyzerK2 {
   /**
    * Analyzes all receivers (extension, dispatch, context) of a function.
    */
-  context(KaSession)
-  private fun analyzeReceivers(
+  private fun KaSession.analyzeReceivers(
     functionSymbol: KaFunctionSymbol,
     inferencer: KtStabilityInferencer,
   ): List<ReceiverStabilityInfo> {
@@ -161,7 +159,7 @@ internal object StabilityAnalyzerK2 {
     @Suppress("EXPERIMENTAL_API_USAGE")
     functionSymbol.receiverParameter?.let { receiver ->
       val receiverType = receiver.returnType
-      val stability = inferencer.ktStabilityOf(receiverType)
+      val stability = with(inferencer) { ktStabilityOf(receiverType) }
 
       receivers.add(
         ReceiverStabilityInfo(
@@ -177,7 +175,7 @@ internal object StabilityAnalyzerK2 {
     @Suppress("EXPERIMENTAL_API_USAGE", "DEPRECATION")
     val dispatchReceiverType = functionSymbol.dispatchReceiverType
     if (dispatchReceiverType != null) {
-      val stability = inferencer.ktStabilityOf(dispatchReceiverType)
+      val stability = with(inferencer) { ktStabilityOf(dispatchReceiverType) }
 
       receivers.add(
         ReceiverStabilityInfo(
@@ -193,7 +191,7 @@ internal object StabilityAnalyzerK2 {
     @Suppress("EXPERIMENTAL_API_USAGE")
     functionSymbol.contextReceivers.forEach { contextReceiver ->
       val contextType = contextReceiver.type
-      val stability = inferencer.ktStabilityOf(contextType)
+      val stability = with(inferencer) { ktStabilityOf(contextType) }
 
       receivers.add(
         ReceiverStabilityInfo(

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/reality/RealityClassifier.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/reality/RealityClassifier.kt
@@ -158,8 +158,9 @@ internal object RealityClassifier {
         else -> RealityGrade.FALSE_ALARM
       }
 
-      // RUNTIME had no firm prediction, so there is no "false alarm" to call — grade on behavior.
-      ParameterStability.RUNTIME -> when {
+      // RUNTIME/UNKNOWN had no firm prediction, so there is no "false alarm" to call —
+      // grade on behavior. (UNKNOWN: interfaces / non-final classes, per Compose 2.4.0.)
+      ParameterStability.RUNTIME, ParameterStability.UNKNOWN -> when {
         equalsChanged > 0 -> RealityGrade.JUSTIFIED
         refChanged > 0 -> RealityGrade.SILENT_WASTE
         else -> RealityGrade.CONFIRMED

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/ComposableStabilityCollector.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/ComposableStabilityCollector.kt
@@ -96,7 +96,7 @@ public class ComposableStabilityCollector(private val project: Project) {
                 name = paramJson.get("name").asString,
                 type = paramJson.get("type").asString,
                 isStable = stability == "STABLE",
-                isRuntime = stability == "RUNTIME",
+                isRuntime = stability == "RUNTIME" || stability == "UNKNOWN",
               )
             }
 

--- a/compose-stability-analyzer-idea/src/test/kotlin/com/skydoves/compose/stability/idea/StabilityKindsTest.kt
+++ b/compose-stability-analyzer-idea/src/test/kotlin/com/skydoves/compose/stability/idea/StabilityKindsTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Designed and developed by 2025 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.compose.stability.idea
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.skydoves.compose.stability.idea.settings.StabilitySettingsState
+import com.skydoves.compose.stability.runtime.ParameterStability
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Locks in the Compose 2.4.0-aligned stability classification across declaration "kinds".
+ *
+ * The Kotlin 2.4.0 migration changed interfaces and non-final (open/abstract) classes to infer
+ * [ParameterStability.UNKNOWN] (mirroring Compose 2.4.0). These tests guard the changed inference
+ * branches against regressions — most importantly that a **generic interface** stays UNKNOWN and
+ * is not accidentally promoted to STABLE just because its type arguments happen to be stable.
+ */
+class StabilityKindsTest : BasePlatformTestCase() {
+
+  private lateinit var snapshot: SettingsSnapshot
+
+  override fun setUp() {
+    super.setUp()
+    val state = StabilitySettingsState.getInstance()
+    snapshot = SettingsSnapshot.fromState(state)
+    state.apply {
+      isStabilityCheckEnabled = true
+      isStrongSkippingEnabled = false
+      ignoredTypePatterns = ""
+      stabilityConfigurationPath = ""
+    }
+  }
+
+  override fun tearDown() {
+    try {
+      snapshot.restore(StabilitySettingsState.getInstance())
+    } finally {
+      super.tearDown()
+    }
+  }
+
+  private fun stabilities(): Map<String, ParameterStability> {
+    val file = myFixture.configureByText(
+      "StabilityKinds.kt",
+      """
+      package test
+
+      import androidx.compose.runtime.Composable
+
+      interface Repo
+      fun interface Handler { fun handle() }
+      sealed interface State
+      open class OpenBase
+      abstract class AbstractBase
+      interface Generic<T>
+      class FinalStable(val id: Int, val name: String)
+      class MutableHolder(var count: Int)
+
+      @Composable
+      fun Screen(
+        repo: Repo,
+        handler: Handler,
+        state: State,
+        openBase: OpenBase,
+        abstractBase: AbstractBase,
+        generic: Generic<String>,
+        finalStable: FinalStable,
+        mutable: MutableHolder,
+      ) { }
+      """.trimIndent(),
+    ) as KtFile
+
+    myFixture.doHighlighting()
+
+    val fn = file.declarations.filterIsInstance<KtNamedFunction>().single { it.name == "Screen" }
+    return StabilityAnalyzer.analyze(fn).parameters.associate { it.name to it.stability }
+  }
+
+  /**
+   * Interfaces and non-final (open/abstract) classes — including a generic interface — must all
+   * infer UNKNOWN, matching the Compose 2.4.0 compiler.
+   */
+  fun testInterfaceAndNonFinalClassesAreUnknown() {
+    val s = stabilities()
+    assertEquals("interface", ParameterStability.UNKNOWN, s["repo"])
+    assertEquals("fun interface", ParameterStability.UNKNOWN, s["handler"])
+    assertEquals("sealed interface", ParameterStability.UNKNOWN, s["state"])
+    assertEquals("open class", ParameterStability.UNKNOWN, s["openBase"])
+    assertEquals("abstract class", ParameterStability.UNKNOWN, s["abstractBase"])
+    // Regression guard: a generic interface must stay UNKNOWN — it must NOT be promoted to STABLE
+    // just because its type argument (String) is stable.
+    assertEquals("generic interface", ParameterStability.UNKNOWN, s["generic"])
+  }
+
+  /**
+   * Final classes are unaffected by the migration: a final class with stable `val` properties is
+   * STABLE, and a class with a mutable `var` is UNSTABLE.
+   */
+  fun testFinalAndMutableClassesUnchanged() {
+    val s = stabilities()
+    assertEquals("final class with stable vals", ParameterStability.STABLE, s["finalStable"])
+    assertEquals("class with mutable var", ParameterStability.UNSTABLE, s["mutable"])
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 
 # Maven publishing
 GROUP=com.github.skydoves
-VERSION_NAME=0.8.0
+VERSION_NAME=0.9.0
 
 POM_URL=https://github.com/skydoves/compose-stability-analyzer/
 POM_SCM_URL=https://github.com/skydoves/compose-stability-analyzer/

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
-compiler = "1.5.15"
 junit = "4.13.2"
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 dokka = "2.2.0"
 jvmTarget = "17"
 kotlinxCollectionsImmutable = "0.4.0"
@@ -13,13 +12,12 @@ androidGradlePlugin = "9.1.1"
 androidxActivity = "1.13.0"
 androidxComposeBom = "2026.05.01"
 jetbrains-compose = "1.11.0"
-compose-stability-analyzer = "0.7.5"
+compose-stability-analyzer = "0.8.0"
 runtimeAnnotation = "1.11.2"
 spotless = "7.0.2"
 shadow = "9.0.0-beta12"
 
 [libraries]
-androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compiler" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }

--- a/stability-compiler/api/stability-compiler.api
+++ b/stability-compiler/api/stability-compiler.api
@@ -155,7 +155,7 @@ public final class com/skydoves/compose/stability/compiler/StabilityReport$Compa
 
 public final class com/skydoves/compose/stability/compiler/lower/RecompositionIrBuilder {
 	public fun <init> (Lorg/jetbrains/kotlin/backend/common/extensions/IrPluginContext;)V
-	public final fun initializeSymbols ()Z
+	public final fun initializeSymbols (Lorg/jetbrains/kotlin/ir/declarations/IrFile;)Z
 	public final fun injectTrackingCode (Lorg/jetbrains/kotlin/ir/declarations/IrFunction;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;Ljava/util/List;)Z
 	public static synthetic fun injectTrackingCode$default (Lcom/skydoves/compose/stability/compiler/lower/RecompositionIrBuilder;Lorg/jetbrains/kotlin/ir/declarations/IrFunction;Ljava/lang/String;Ljava/lang/String;ILjava/util/List;Ljava/util/List;ILjava/lang/Object;)Z
 }

--- a/stability-compiler/build.gradle.kts
+++ b/stability-compiler/build.gradle.kts
@@ -25,10 +25,6 @@ plugins {
 
 kotlin {
   explicitApi()
-
-  compilerOptions {
-    freeCompilerArgs.add("-Xcontext-parameters")
-  }
 }
 
 dependencies {

--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerPluginRegistrar.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/StabilityAnalyzerPluginRegistrar.kt
@@ -18,8 +18,9 @@ package com.skydoves.compose.stability.compiler
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.jetbrains.kotlin.compiler.plugin.registerExtension
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
+import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 
 @OptIn(ExperimentalCompilerApi::class)
 public class StabilityAnalyzerPluginRegistrar : CompilerPluginRegistrar() {
@@ -45,8 +46,11 @@ public class StabilityAnalyzerPluginRegistrar : CompilerPluginRegistrar() {
       "",
     )
 
-    // Register FIR extensions for frontend analysis (K2)
-    FirExtensionRegistrarAdapter.registerExtension(
+    // Register FIR extensions for frontend analysis (K2).
+    // Kotlin 2.4.0 (KT-83341) moved K2 extension registration off the IntelliJ
+    // ProjectExtensionDescriptor mechanism; use the ExtensionStorage-scoped helpers so the
+    // adapter companion isn't cast to the removed descriptor type at runtime.
+    FirExtensionRegistrar.registerExtension(
       StabilityAnalyzerFirExtensionRegistrar(),
     )
 

--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/lower/RecompositionIrBuilder.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/lower/RecompositionIrBuilder.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.ir.builders.irCall
 import org.jetbrains.kotlin.ir.builders.irGet
 import org.jetbrains.kotlin.ir.builders.irInt
 import org.jetbrains.kotlin.ir.builders.irString
+import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.declarations.IrLocalDelegatedProperty
 import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
@@ -77,10 +78,14 @@ public class RecompositionIrBuilder(private val context: IrPluginContext) {
    * Initialize and cache symbols for runtime classes.
    * This should be called before any IR generation.
    */
-  public fun initializeSymbols(): Boolean {
+  public fun initializeSymbols(fromFile: IrFile): Boolean {
     try {
+      // Resolve runtime symbols visible from the file being compiled.
+      // Replaces the deprecated global IrPluginContext.reference* methods (Kotlin 2.4.0).
+      val finder = context.finderForSource(fromFile)
+
       // Find RecompositionTracker class
-      trackerClassSymbol = context.referenceClass(
+      trackerClassSymbol = finder.findClass(
         ClassId.topLevel(recompositionTrackerFqName),
       )
 
@@ -89,7 +94,7 @@ public class RecompositionIrBuilder(private val context: IrPluginContext) {
       }
 
       // Find rememberRecompositionTracker function
-      val rememberTrackerFunctions = context.referenceFunctions(
+      val rememberTrackerFunctions = finder.findFunctions(
         CallableId(
           FqName("com.skydoves.compose.stability.runtime"),
           Name.identifier("rememberRecompositionTracker"),
@@ -133,7 +138,7 @@ public class RecompositionIrBuilder(private val context: IrPluginContext) {
 
       // Resolve System.nanoTime() for JVM platforms
       try {
-        val systemClass = context.referenceClass(
+        val systemClass = finder.findClass(
           ClassId.topLevel(FqName("java.lang.System")),
         )
         systemNanoTimeFunctionSymbol =

--- a/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/lower/StabilityAnalyzerTransformer.kt
+++ b/stability-compiler/src/main/kotlin/com/skydoves/compose/stability/compiler/lower/StabilityAnalyzerTransformer.kt
@@ -166,7 +166,7 @@ public class StabilityAnalyzerTransformer(
 
       // Initialize IR builder symbols once
       if (!irBuilderInitialized) {
-        irBuilderInitialized = irBuilder.initializeSymbols()
+        irBuilderInitialized = irBuilder.initializeSymbols(currentFile)
         if (!irBuilderInitialized) {
           return super.visitFunctionNew(declaration)
         }
@@ -563,12 +563,12 @@ public class StabilityAnalyzerTransformer(
       // If properties have mixed stability, fall through to interface check
     }
 
-    // 15. Interfaces - cannot determine (RUNTIME)
+    // 15. Interfaces - concrete implementation unknown (Compose 2.4.0: Unknown)
     if (clazz.isInterfaceIr()) {
-      return ParameterStability.RUNTIME
+      return ParameterStability.UNKNOWN
     }
 
-    // 16. Abstract classes - cannot determine (RUNTIME)
+    // 16. Abstract classes - concrete implementation unknown (Compose 2.4.0: Unknown)
     //     EXCEPT: sealed classes with @Stable/@Immutable annotations
     //     Issue #31: @Immutable sealed classes should be trusted as stable
     if (clazz.modality == org.jetbrains.kotlin.descriptors.Modality.ABSTRACT) {
@@ -583,11 +583,20 @@ public class StabilityAnalyzerTransformer(
       val hasStabilityAnnotation = clazz.hasAnnotation(stableFqName) ||
         clazz.hasAnnotation(immutableFqName)
 
-      // Only mark as RUNTIME if it's NOT a sealed class AND doesn't have stability annotation
+      // Only mark as UNKNOWN if it's NOT a sealed class AND doesn't have stability annotation
       if (!isSealed && !hasStabilityAnnotation) {
-        return ParameterStability.RUNTIME
+        return ParameterStability.UNKNOWN
       }
       // Sealed classes and annotated abstract classes continue to property analysis
+    }
+
+    // 16b. Non-final (open) classes - concrete subtype unknown (Compose 2.4.0: Unknown)
+    //      EXCEPT: classes explicitly trusted via @Stable/@Immutable.
+    if (clazz.modality == org.jetbrains.kotlin.descriptors.Modality.OPEN &&
+      !clazz.hasAnnotation(stableFqName) &&
+      !clazz.hasAnnotation(immutableFqName)
+    ) {
+      return ParameterStability.UNKNOWN
     }
 
     // 17. Cross-module types require explicit @Stable/@Immutable/@StabilityInferred
@@ -604,6 +613,7 @@ public class StabilityAnalyzerTransformer(
     when (propertyStability) {
       ParameterStability.STABLE -> return ParameterStability.STABLE
       ParameterStability.UNSTABLE -> return ParameterStability.UNSTABLE
+      ParameterStability.UNKNOWN -> return ParameterStability.UNKNOWN
       ParameterStability.RUNTIME -> {
         // 19. Check @StabilityInferred: parameters=0 means stable, else runtime
         val stabilityInferredParams = type.getStabilityInferredParameters()
@@ -944,6 +954,7 @@ public class StabilityAnalyzerTransformer(
     ParameterStability.STABLE -> "STABLE"
     ParameterStability.UNSTABLE -> "UNSTABLE"
     ParameterStability.RUNTIME -> "RUNTIME"
+    ParameterStability.UNKNOWN -> "UNKNOWN"
   }
 
   /**
@@ -967,6 +978,7 @@ public class StabilityAnalyzerTransformer(
       else -> "has mutable properties or unstable members"
     }
     "RUNTIME" -> "requires runtime check"
+    "UNKNOWN" -> "interface or non-final class; concrete implementation unknown"
     else -> null
   }
 

--- a/stability-gradle/api/stability-gradle.api
+++ b/stability-gradle/api/stability-gradle.api
@@ -13,7 +13,6 @@ public final class com/skydoves/compose/stability/gradle/StabilityAnalyzerGradle
 	public fun applyToCompilation (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Lorg/gradle/api/provider/Provider;
 	public fun getCompilerPluginId ()Ljava/lang/String;
 	public fun getPluginArtifact ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
-	public fun getPluginArtifactForNative ()Lorg/jetbrains/kotlin/gradle/plugin/SubpluginArtifact;
 	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
 }
 

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -45,9 +45,10 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
     private const val COMPILER_ARTIFACT_ID = "compose-stability-compiler"
     private const val RUNTIME_ARTIFACT_ID = "compose-stability-runtime"
 
-    // This version should match the version in gradle.properties
-    // Update this when bumping the library version
-    private const val VERSION = "0.7.5"
+    // This version should match the version in gradle.properties (VERSION_NAME).
+    // Update this when bumping the library version — it pins the compiler/runtime
+    // artifacts the Gradle plugin pulls onto the Kotlin compile classpath.
+    private const val VERSION = "0.9.0"
 
     // Compiler option keys
     private const val OPTION_ENABLED = "enabled"
@@ -263,12 +264,6 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
   override fun getCompilerPluginId(): String = COMPILER_PLUGIN_ID
 
   override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-    groupId = GROUP_ID,
-    artifactId = COMPILER_ARTIFACT_ID,
-    version = VERSION,
-  )
-
-  override fun getPluginArtifactForNative(): SubpluginArtifact = SubpluginArtifact(
     groupId = GROUP_ID,
     artifactId = COMPILER_ARTIFACT_ID,
     version = VERSION,

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityDumpTask.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityDumpTask.kt
@@ -380,6 +380,6 @@ internal data class StabilityEntry(
 internal data class ParameterInfo(
   val name: String,
   val type: String,
-  val stability: String, // STABLE, UNSTABLE, RUNTIME
+  val stability: String, // STABLE, UNSTABLE, RUNTIME, UNKNOWN
   val reason: String? = null,
 )

--- a/stability-runtime/api/android/stability-runtime.api
+++ b/stability-runtime/api/android/stability-runtime.api
@@ -72,6 +72,7 @@ public final class com/skydoves/compose/stability/runtime/ParameterChange {
 public final class com/skydoves/compose/stability/runtime/ParameterStability : java/lang/Enum {
 	public static final field RUNTIME Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static final field STABLE Lcom/skydoves/compose/stability/runtime/ParameterStability;
+	public static final field UNKNOWN Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static final field UNSTABLE Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/compose/stability/runtime/ParameterStability;

--- a/stability-runtime/api/jvm/stability-runtime.api
+++ b/stability-runtime/api/jvm/stability-runtime.api
@@ -72,6 +72,7 @@ public final class com/skydoves/compose/stability/runtime/ParameterChange {
 public final class com/skydoves/compose/stability/runtime/ParameterStability : java/lang/Enum {
 	public static final field RUNTIME Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static final field STABLE Lcom/skydoves/compose/stability/runtime/ParameterStability;
+	public static final field UNKNOWN Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static final field UNSTABLE Lcom/skydoves/compose/stability/runtime/ParameterStability;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/skydoves/compose/stability/runtime/ParameterStability;

--- a/stability-runtime/src/commonMain/kotlin/com/skydoves/compose/stability/runtime/StabilityModels.kt
+++ b/stability-runtime/src/commonMain/kotlin/com/skydoves/compose/stability/runtime/StabilityModels.kt
@@ -33,6 +33,16 @@ public enum class ParameterStability {
    * The stability can only be determined at runtime.
    */
   RUNTIME,
+
+  /**
+   * The stability cannot be determined statically because the concrete type is
+   * unknown — e.g. an interface or a non-final (open/abstract) class whose actual
+   * implementation could be anything. Mirrors Compose 2.4.0's `Stability.Unknown`,
+   * which the compiler now infers for interfaces and non-final classes by default.
+   * Treated as not statically stable (a composable with an UNKNOWN parameter is not
+   * skippable unless strong skipping applies).
+   */
+  UNKNOWN,
 }
 
 /**

--- a/stability-runtime/src/commonTest/kotlin/com/skydoves/compose/stability/runtime/ReceiverStabilityInfoTest.kt
+++ b/stability-runtime/src/commonTest/kotlin/com/skydoves/compose/stability/runtime/ReceiverStabilityInfoTest.kt
@@ -202,9 +202,10 @@ class ReceiverStabilityInfoTest {
 
   @Test
   fun testParameterStability_values() {
-    assertEquals(3, ParameterStability.entries.size)
+    assertEquals(4, ParameterStability.entries.size)
     assertEquals(ParameterStability.STABLE, ParameterStability.valueOf("STABLE"))
     assertEquals(ParameterStability.UNSTABLE, ParameterStability.valueOf("UNSTABLE"))
     assertEquals(ParameterStability.RUNTIME, ParameterStability.valueOf("RUNTIME"))
+    assertEquals(ParameterStability.UNKNOWN, ParameterStability.valueOf("UNKNOWN"))
   }
 }


### PR DESCRIPTION
Migrate to Kotlin 2.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.9.0

* **New Features**
  * Introduced UNKNOWN stability classification for interfaces and non-final classes in stability analysis.
  * Added support for Kotlin 2.4.0.

* **Documentation**
  * Updated README and changelog with new stability value documentation and version mappings.

* **Tests**
  * Added comprehensive test coverage for stability classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->