### PR TITLE
Prevent gradle plugin from leaking AGP9 downstream

### DIFF
--- a/stability-gradle/build.gradle.kts
+++ b/stability-gradle/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
 
 dependencies {
   compileOnly(kotlin("gradle-plugin", version = libs.versions.kotlin.get()))
-  implementation(libs.android.gradleApi)
+  compileOnly(libs.android.gradleApi)
 
   testImplementation(kotlin("test"))
   testImplementation(kotlin("test-junit"))

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/AndroidStabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/AndroidStabilityTaskRegistrar.kt
@@ -16,6 +16,7 @@
 package com.skydoves.compose.stability.gradle
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.getLintProject
 import org.gradle.api.Project
 
 /**
@@ -23,7 +24,7 @@ import org.gradle.api.Project
  */
 internal class AndroidStabilityTaskRegistrar : StabilityTaskRegistrar() {
 
-  override fun register(target: Project, extension: StabilityAnalyzerExtension) {
+  override fun registerStabilityTasks(target: Project, extension: StabilityAnalyzerExtension) {
     val androidComponents =
       target.extensions.getByType(AndroidComponentsExtension::class.java)
 
@@ -109,6 +110,12 @@ internal class AndroidStabilityTaskRegistrar : StabilityTaskRegistrar() {
 
     target.afterEvaluate {
       addRuntimeDependency(target)
+    }
+  }
+
+  override fun registerLintingTask(target: Project) {
+    getLintProject(target) ?.let { lintProject ->
+      target.dependencies.add("lintChecks", lintProject)
     }
   }
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/AndroidStabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/AndroidStabilityTaskRegistrar.kt
@@ -1,0 +1,114 @@
+/*
+ * Designed and developed by 2025 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.compose.stability.gradle
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Project
+
+/**
+ * Registers stability tasks for Android projects, per variant.
+ */
+internal class AndroidStabilityTaskRegistrar : StabilityTaskRegistrar() {
+
+  override fun register(target: Project, extension: StabilityAnalyzerExtension) {
+    val androidComponents =
+      target.extensions.getByType(AndroidComponentsExtension::class.java)
+
+    val aggregateDumpTask = target.tasks.register("stabilityDump") {
+      group = "verification"
+      description = "Dump composable stability information to stability file"
+    }
+    val aggregateCheckTask = target.tasks.register("stabilityCheck") {
+      group = "verification"
+      description = "Check composable stability against reference file"
+    }
+
+    androidComponents.onVariants { variant ->
+      val variantNameLowerCase = variant.name.replaceFirstChar { it.lowercaseChar() }
+      val variantNameUpperCase = variant.name.replaceFirstChar { it.uppercaseChar() }
+
+      // Register stability dump task
+      val stabilityDumpTask = target.tasks.register(
+        "${variantNameLowerCase}StabilityDump",
+        StabilityDumpTask::class.java,
+      ) {
+        projectName.set(target.name)
+        stabilityInputFiles.setFrom(
+          target.layout.buildDirectory.file(
+            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
+          ),
+        )
+        outputDir.set(extension.stabilityValidation.outputDir)
+        ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
+        ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
+        stabilityFileSuffix.set(variant.name)
+        stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+        unstableOnly.set(extension.stabilityValidation.unstableOnly)
+      }
+
+      // Register stability check task
+      val stabilityCheckTask = target.tasks.register(
+        "${variantNameLowerCase}StabilityCheck",
+        StabilityCheckTask::class.java,
+      ) {
+        projectName.set(target.name)
+        stabilityInputFiles.from(
+          target.layout.buildDirectory.file(
+            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
+          ),
+        )
+        stabilityReferenceFiles.from(extension.stabilityValidation.outputDir)
+        ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
+        ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
+        failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
+        quietCheck.set(extension.stabilityValidation.quietCheck)
+        stabilityFileSuffix.set(variant.name)
+        ignoreNonRegressiveChanges.set(extension.stabilityValidation.ignoreNonRegressiveChanges)
+        allowMissingBaseline.set(extension.stabilityValidation.allowMissingBaseline)
+        stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+      }
+
+      aggregateDumpTask.configure {
+        dependsOn(stabilityDumpTask)
+      }
+      aggregateCheckTask.configure {
+        dependsOn(stabilityCheckTask)
+      }
+
+      // Make check task depend on stabilityCheck if enabled (only if check task exists)
+      target.plugins.withId("base") {
+        target.tasks.named("check") {
+          dependsOn(stabilityCheckTask)
+        }
+      }
+
+      // Configure after project evaluation
+      target.afterEvaluate {
+        configureTaskDependencies(
+          target,
+          extension,
+          variantNameUpperCase,
+          stabilityDumpTask,
+          stabilityCheckTask,
+        )
+      }
+    }
+
+    target.afterEvaluate {
+      addRuntimeDependency(target)
+    }
+  }
+}

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/JvmStabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/JvmStabilityTaskRegistrar.kt
@@ -1,0 +1,78 @@
+/*
+ * Designed and developed by 2025 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.compose.stability.gradle
+
+import org.gradle.api.Project
+
+/**
+ * Registers stability tasks for non-Android (JVM/KMP) projects.
+ */
+internal class JvmStabilityTaskRegistrar : StabilityTaskRegistrar() {
+
+  override fun register(target: Project, extension: StabilityAnalyzerExtension) {
+    // Register stability dump task
+    val stabilityDumpTask = target.tasks.register(
+      "stabilityDump",
+      StabilityDumpTask::class.java,
+    ) {
+      projectName.set(target.name)
+      stabilityInputFiles.setFrom(
+        target.fileTree(target.layout.buildDirectory.dir("stability")) {
+          include("*/stability-info.json")
+        },
+      )
+      outputDir.set(extension.stabilityValidation.outputDir)
+      ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
+      ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
+      stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+      unstableOnly.set(extension.stabilityValidation.unstableOnly)
+    }
+
+    // Register stability check task
+    val stabilityCheckTask = target.tasks.register(
+      "stabilityCheck",
+      StabilityCheckTask::class.java,
+    ) {
+      projectName.set(target.name)
+      stabilityInputFiles.from(
+        target.fileTree(target.layout.buildDirectory.dir("stability")) {
+          include("*/stability-info.json")
+        },
+      )
+      stabilityReferenceFiles.from(extension.stabilityValidation.outputDir)
+      ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
+      ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
+      failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
+      quietCheck.set(extension.stabilityValidation.quietCheck)
+      ignoreNonRegressiveChanges.set(extension.stabilityValidation.ignoreNonRegressiveChanges)
+      allowMissingBaseline.set(extension.stabilityValidation.allowMissingBaseline)
+      stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
+    }
+
+    // Make check task depend on stabilityCheck if enabled (only if check task exists)
+    target.plugins.withId("base") {
+      target.tasks.named("check") {
+        dependsOn(stabilityCheckTask)
+      }
+    }
+
+    // Configure after project evaluation
+    target.afterEvaluate {
+      configureTaskDependencies(target, extension, null, stabilityDumpTask, stabilityCheckTask)
+      addRuntimeDependency(target)
+    }
+  }
+}

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/JvmStabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/JvmStabilityTaskRegistrar.kt
@@ -22,7 +22,7 @@ import org.gradle.api.Project
  */
 internal class JvmStabilityTaskRegistrar : StabilityTaskRegistrar() {
 
-  override fun register(target: Project, extension: StabilityAnalyzerExtension) {
+  override fun registerStabilityTasks(target: Project, extension: StabilityAnalyzerExtension) {
     // Register stability dump task
     val stabilityDumpTask = target.tasks.register(
       "stabilityDump",
@@ -74,5 +74,9 @@ internal class JvmStabilityTaskRegistrar : StabilityTaskRegistrar() {
       configureTaskDependencies(target, extension, null, stabilityDumpTask, stabilityCheckTask)
       addRuntimeDependency(target)
     }
+  }
+
+  override fun registerLintingTask(target: Project) {
+    // No linting tasks exist for JVM/KMP projects.
   }
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -82,7 +82,7 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
       } else {
         JvmStabilityTaskRegistrar()
       }
-    registrar.register(target, extension)
+    registrar.registerStabilityTasks(target, extension)
 
     // Per-task output directory to avoid shared output conflicts with other plugins (Issue #153)
     target.tasks.withType(KotlinCompile::class.java).configureEach {

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityAnalyzerGradlePlugin.kt
@@ -15,13 +15,10 @@
  */
 package com.skydoves.compose.stability.gradle
 
-import com.android.build.api.variant.AndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_MAIN_SOURCE_SET_NAME
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -38,22 +35,34 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
   public companion object {
     // Plugin IDs
     private const val COMPILER_PLUGIN_ID = "com.skydoves.compose.stability.compiler"
-    private const val MULTIPLATFORM_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
+    internal const val MULTIPLATFORM_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
 
     // Artifact coordinates
-    private const val GROUP_ID = "com.github.skydoves"
+    internal const val GROUP_ID = "com.github.skydoves"
     private const val COMPILER_ARTIFACT_ID = "compose-stability-compiler"
-    private const val RUNTIME_ARTIFACT_ID = "compose-stability-runtime"
+    internal const val RUNTIME_ARTIFACT_ID = "compose-stability-runtime"
 
     // This version should match the version in gradle.properties (VERSION_NAME).
     // Update this when bumping the library version — it pins the compiler/runtime
     // artifacts the Gradle plugin pulls onto the Kotlin compile classpath.
-    private const val VERSION = "0.9.0"
+    internal const val VERSION = "0.9.0"
 
     // Compiler option keys
     private const val OPTION_ENABLED = "enabled"
     private const val OPTION_STABILITY_OUTPUT_DIR = "stabilityOutputDir"
     private const val OPTION_PROJECT_DEPENDENCIES = "projectDependencies"
+
+    /**
+     * Get the runtime project if available.
+     */
+    internal fun getRuntimeProject(project: Project): Project? =
+      project.rootProject.findProject(":stability-runtime")
+
+    /**
+     * Get the lint project if available.
+     */
+    internal fun getLintProject(project: Project): Project? =
+      project.rootProject.findProject(":stability-lint")
   }
 
   override fun apply(target: Project) {
@@ -67,12 +76,13 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
     // Add runtime to compiler plugin classpath for all compilations
     addRuntimeToCompilerClasspath(target)
 
-    val androidComponents = target.extensions.findByType(AndroidComponentsExtension::class.java)
-    if (androidComponents == null) {
-      registerTasksNonAndroid(target, extension)
-    } else {
-      registerTasksAndroid(target, extension, androidComponents)
-    }
+    val registrar =
+      if (target.plugins.hasPlugin("com.android.base")) {
+        AndroidStabilityTaskRegistrar()
+      } else {
+        JvmStabilityTaskRegistrar()
+      }
+    registrar.register(target, extension)
 
     // Per-task output directory to avoid shared output conflicts with other plugins (Issue #153)
     target.tasks.withType(KotlinCompile::class.java).configureEach {
@@ -94,150 +104,6 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
           }
         }
       }
-    }
-  }
-
-  private fun registerTasksNonAndroid(target: Project, extension: StabilityAnalyzerExtension) {
-    // Register stability dump task
-    val stabilityDumpTask = target.tasks.register(
-      "stabilityDump",
-      StabilityDumpTask::class.java,
-    ) {
-      projectName.set(target.name)
-      stabilityInputFiles.setFrom(
-        target.fileTree(target.layout.buildDirectory.dir("stability")) {
-          include("*/stability-info.json")
-        },
-      )
-      outputDir.set(extension.stabilityValidation.outputDir)
-      ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
-      ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
-      stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
-      unstableOnly.set(extension.stabilityValidation.unstableOnly)
-    }
-
-    // Register stability check task
-    val stabilityCheckTask = target.tasks.register(
-      "stabilityCheck",
-      StabilityCheckTask::class.java,
-    ) {
-      projectName.set(target.name)
-      stabilityInputFiles.from(
-        target.fileTree(target.layout.buildDirectory.dir("stability")) {
-          include("*/stability-info.json")
-        },
-      )
-      stabilityReferenceFiles.from(extension.stabilityValidation.outputDir)
-      ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
-      ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
-      failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
-      quietCheck.set(extension.stabilityValidation.quietCheck)
-      ignoreNonRegressiveChanges.set(extension.stabilityValidation.ignoreNonRegressiveChanges)
-      allowMissingBaseline.set(extension.stabilityValidation.allowMissingBaseline)
-      stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
-    }
-
-    // Make check task depend on stabilityCheck if enabled (only if check task exists)
-    target.plugins.withId("base") {
-      target.tasks.named("check") {
-        dependsOn(stabilityCheckTask)
-      }
-    }
-
-    // Configure after project evaluation
-    target.afterEvaluate {
-      configureTaskDependencies(target, extension, null, stabilityDumpTask, stabilityCheckTask)
-      addRuntimeDependency(target)
-    }
-  }
-
-  private fun registerTasksAndroid(
-    target: Project,
-    extension: StabilityAnalyzerExtension,
-    androidComponents: AndroidComponentsExtension<*, *, *>,
-  ) {
-    val aggregateDumpTask = target.tasks.register("stabilityDump") {
-      group = "verification"
-      description = "Dump composable stability information to stability file"
-    }
-    val aggregateCheckTask = target.tasks.register("stabilityCheck") {
-      group = "verification"
-      description = "Check composable stability against reference file"
-    }
-
-    androidComponents.onVariants { variant ->
-      val variantNameLowerCase = variant.name.replaceFirstChar { it.lowercaseChar() }
-      val variantNameUpperCase = variant.name.replaceFirstChar { it.uppercaseChar() }
-
-      // Register stability dump task
-      val stabilityDumpTask = target.tasks.register(
-        "${variantNameLowerCase}StabilityDump",
-        StabilityDumpTask::class.java,
-      ) {
-        projectName.set(target.name)
-        stabilityInputFiles.setFrom(
-          target.layout.buildDirectory.file(
-            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
-          ),
-        )
-        outputDir.set(extension.stabilityValidation.outputDir)
-        ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
-        ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
-        stabilityFileSuffix.set(variant.name)
-        stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
-        unstableOnly.set(extension.stabilityValidation.unstableOnly)
-      }
-
-      // Register stability check task
-      val stabilityCheckTask = target.tasks.register(
-        "${variantNameLowerCase}StabilityCheck",
-        StabilityCheckTask::class.java,
-      ) {
-        projectName.set(target.name)
-        stabilityInputFiles.from(
-          target.layout.buildDirectory.file(
-            "stability/compile${variantNameUpperCase}Kotlin/stability-info.json",
-          ),
-        )
-        stabilityReferenceFiles.from(extension.stabilityValidation.outputDir)
-        ignoredPackages.set(extension.stabilityValidation.ignoredPackages)
-        ignoredClasses.set(extension.stabilityValidation.ignoredClasses)
-        failOnStabilityChange.set(extension.stabilityValidation.failOnStabilityChange)
-        quietCheck.set(extension.stabilityValidation.quietCheck)
-        stabilityFileSuffix.set(variant.name)
-        ignoreNonRegressiveChanges.set(extension.stabilityValidation.ignoreNonRegressiveChanges)
-        allowMissingBaseline.set(extension.stabilityValidation.allowMissingBaseline)
-        stabilityConfigurationFiles.set(extension.stabilityValidation.stabilityConfigurationFiles)
-      }
-
-      aggregateDumpTask.configure {
-        dependsOn(stabilityDumpTask)
-      }
-      aggregateCheckTask.configure {
-        dependsOn(stabilityCheckTask)
-      }
-
-      // Make check task depend on stabilityCheck if enabled (only if check task exists)
-      target.plugins.withId("base") {
-        target.tasks.named("check") {
-          dependsOn(stabilityCheckTask)
-        }
-      }
-
-      // Configure after project evaluation
-      target.afterEvaluate {
-        configureTaskDependencies(
-          target,
-          extension,
-          variantNameUpperCase,
-          stabilityDumpTask,
-          stabilityCheckTask,
-        )
-      }
-    }
-
-    target.afterEvaluate {
-      addRuntimeDependency(target)
     }
   }
 
@@ -320,98 +186,6 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
         }
       }
     }
-  }
-
-  /**
-   * Add runtime dependency to the project.
-   * For multiplatform projects, adds to commonMain sourceSet.
-   * For JVM/Android projects, adds to implementation configuration.
-   */
-  private fun addRuntimeDependency(project: Project) {
-    val runtimeProject = getRuntimeProject(project)
-    val lintProject = getLintProject(project)
-
-    val runtimeDependency = runtimeProject
-      ?: "$GROUP_ID:$RUNTIME_ARTIFACT_ID:$VERSION"
-
-    // Check if this is a multiplatform project
-    if (project.plugins.hasPlugin(MULTIPLATFORM_PLUGIN_ID)) {
-      // For multiplatform projects, add dependency to commonMain sourceSet
-      val kotlinExtension = project.extensions.getByName("kotlin") as KotlinSourceSetContainer
-      val commonMain = kotlinExtension.sourceSets.getByName(COMMON_MAIN_SOURCE_SET_NAME)
-      commonMain.dependencies {
-        implementation(runtimeDependency)
-      }
-    } else {
-      // For JVM/Android projects, add to implementation configuration
-      project.dependencies.add("implementation", runtimeDependency)
-
-      // Lint is only supported for Android projects
-      if (lintProject != null) {
-        project.dependencies.add("lintChecks", lintProject)
-      }
-    }
-  }
-
-  /**
-   * Configure task dependencies for stability dump and check tasks.
-   * Uses lazy configuration to avoid eager task resolution and Gradle 9.x compatibility issues.
-   */
-  private fun configureTaskDependencies(
-    project: Project,
-    extension: StabilityAnalyzerExtension,
-    filter: String? = null,
-    stabilityDumpTask: org.gradle.api.tasks.TaskProvider<StabilityDumpTask>,
-    stabilityCheckTask: org.gradle.api.tasks.TaskProvider<StabilityCheckTask>,
-  ) {
-    // Get the includeTests provider for lazy evaluation
-    val includeTestsProvider = extension.stabilityValidation.includeTests
-
-    // Configure dependencies lazily using TaskProvider
-    stabilityDumpTask.configure {
-      dependsOn(
-        includeTestsProvider.map { includeTests ->
-          project.tasks.matching { task ->
-            isKotlinTaskApplicable(task.name, includeTests) &&
-              (filter == null || task.name.contains(filter))
-          }
-        },
-      )
-    }
-
-    stabilityCheckTask.configure {
-      dependsOn(
-        includeTestsProvider.map { includeTests ->
-          project.tasks.matching { task ->
-            isKotlinTaskApplicable(task.name, includeTests) &&
-              (filter == null || task.name.contains(filter))
-          }
-        },
-      )
-    }
-  }
-
-  private fun isKotlinTaskApplicable(taskName: String, includeTests: Boolean): Boolean {
-    val taskNameLower = taskName.lowercase()
-
-    // Match only actual Kotlin compilation tasks, excluding infrastructure tasks
-    val isKotlinCompile = taskName.startsWith("compile") &&
-      taskName.contains("Kotlin") &&
-      // Exclude wasm-specific sync/webpack/executable tasks
-      !taskNameLower.contains("sync") &&
-      !taskNameLower.contains("webpack") &&
-      !taskNameLower.contains("executable") &&
-      !taskNameLower.contains("link") &&
-      !taskNameLower.contains("assemble")
-
-    val isTestTask = taskNameLower.let {
-      it.contains("test") || it.contains("androidtest") || it.contains("unittest")
-    }
-
-    // Include task if it's a Kotlin compile task and either:
-    // 1. includeTests is true, OR
-    // 2. it's not a test task
-    return isKotlinCompile && (includeTests || !isTestTask)
   }
 
   /**
@@ -502,16 +276,4 @@ public class StabilityAnalyzerGradlePlugin : KotlinCompilerPluginSupportPlugin {
   private fun getCompilerProject(): Project? {
     return null // Will be resolved from current project's rootProject in actual usage
   }
-
-  /**
-   * Get the runtime project if available.
-   */
-  private fun getRuntimeProject(project: Project): Project? =
-    project.rootProject.findProject(":stability-runtime")
-
-  /**
-   * Get the lint project if available.
-   */
-  private fun getLintProject(project: Project): Project? =
-    project.rootProject.findProject(":stability-lint")
 }

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityTaskRegistrar.kt
@@ -19,7 +19,6 @@ import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Compa
 import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.MULTIPLATFORM_PLUGIN_ID
 import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.RUNTIME_ARTIFACT_ID
 import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.VERSION
-import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.getLintProject
 import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.getRuntimeProject
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
@@ -34,7 +33,9 @@ internal abstract class StabilityTaskRegistrar {
   /**
    * Registers stability tasks for the [target] project.
    */
-  abstract fun register(target: Project, extension: StabilityAnalyzerExtension)
+  abstract fun registerStabilityTasks(target: Project, extension: StabilityAnalyzerExtension)
+
+  protected abstract fun registerLintingTask(target: Project)
 
   /**
    * Add runtime dependency to the project.
@@ -43,7 +44,6 @@ internal abstract class StabilityTaskRegistrar {
    */
   protected fun addRuntimeDependency(project: Project) {
     val runtimeProject = getRuntimeProject(project)
-    val lintProject = getLintProject(project)
 
     val runtimeDependency = runtimeProject
       ?: "$GROUP_ID:$RUNTIME_ARTIFACT_ID:$VERSION"
@@ -59,12 +59,9 @@ internal abstract class StabilityTaskRegistrar {
     } else {
       // For JVM/Android projects, add to implementation configuration
       project.dependencies.add("implementation", runtimeDependency)
-
-      // Lint is only supported for Android projects
-      if (lintProject != null) {
-        project.dependencies.add("lintChecks", lintProject)
-      }
     }
+
+    registerLintingTask(project)
   }
 
   /**

--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityTaskRegistrar.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityTaskRegistrar.kt
@@ -1,0 +1,130 @@
+/*
+ * Designed and developed by 2025 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.compose.stability.gradle
+
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.GROUP_ID
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.MULTIPLATFORM_PLUGIN_ID
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.RUNTIME_ARTIFACT_ID
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.VERSION
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.getLintProject
+import com.skydoves.compose.stability.gradle.StabilityAnalyzerGradlePlugin.Companion.getRuntimeProject
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet.Companion.COMMON_MAIN_SOURCE_SET_NAME
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
+
+/**
+ * Base class to register stability tasks.
+ */
+internal abstract class StabilityTaskRegistrar {
+
+  /**
+   * Registers stability tasks for the [target] project.
+   */
+  abstract fun register(target: Project, extension: StabilityAnalyzerExtension)
+
+  /**
+   * Add runtime dependency to the project.
+   * For multiplatform projects, adds to commonMain sourceSet.
+   * For JVM/Android projects, adds to implementation configuration.
+   */
+  protected fun addRuntimeDependency(project: Project) {
+    val runtimeProject = getRuntimeProject(project)
+    val lintProject = getLintProject(project)
+
+    val runtimeDependency = runtimeProject
+      ?: "$GROUP_ID:$RUNTIME_ARTIFACT_ID:$VERSION"
+
+    // Check if this is a multiplatform project
+    if (project.plugins.hasPlugin(MULTIPLATFORM_PLUGIN_ID)) {
+      // For multiplatform projects, add dependency to commonMain sourceSet
+      val kotlinExtension = project.extensions.getByName("kotlin") as KotlinSourceSetContainer
+      val commonMain = kotlinExtension.sourceSets.getByName(COMMON_MAIN_SOURCE_SET_NAME)
+      commonMain.dependencies {
+        implementation(runtimeDependency)
+      }
+    } else {
+      // For JVM/Android projects, add to implementation configuration
+      project.dependencies.add("implementation", runtimeDependency)
+
+      // Lint is only supported for Android projects
+      if (lintProject != null) {
+        project.dependencies.add("lintChecks", lintProject)
+      }
+    }
+  }
+
+  /**
+   * Configure task dependencies for stability dump and check tasks.
+   * Uses lazy configuration to avoid eager task resolution and Gradle 9.x compatibility issues.
+   */
+  protected fun configureTaskDependencies(
+    project: Project,
+    extension: StabilityAnalyzerExtension,
+    filter: String? = null,
+    stabilityDumpTask: TaskProvider<StabilityDumpTask>,
+    stabilityCheckTask: TaskProvider<StabilityCheckTask>,
+  ) {
+    // Get the includeTests provider for lazy evaluation
+    val includeTestsProvider = extension.stabilityValidation.includeTests
+
+    // Configure dependencies lazily using TaskProvider
+    stabilityDumpTask.configure {
+      dependsOn(
+        includeTestsProvider.map { includeTests ->
+          project.tasks.matching { task ->
+            isKotlinTaskApplicable(task.name, includeTests) &&
+              (filter == null || task.name.contains(filter))
+          }
+        },
+      )
+    }
+
+    stabilityCheckTask.configure {
+      dependsOn(
+        includeTestsProvider.map { includeTests ->
+          project.tasks.matching { task ->
+            isKotlinTaskApplicable(task.name, includeTests) &&
+              (filter == null || task.name.contains(filter))
+          }
+        },
+      )
+    }
+  }
+
+  private fun isKotlinTaskApplicable(taskName: String, includeTests: Boolean): Boolean {
+    val taskNameLower = taskName.lowercase()
+
+    // Match only actual Kotlin compilation tasks, excluding infrastructure tasks
+    val isKotlinCompile = taskName.startsWith("compile") &&
+      taskName.contains("Kotlin") &&
+      // Exclude wasm-specific sync/webpack/executable tasks
+      !taskNameLower.contains("sync") &&
+      !taskNameLower.contains("webpack") &&
+      !taskNameLower.contains("executable") &&
+      !taskNameLower.contains("link") &&
+      !taskNameLower.contains("assemble")
+
+    val isTestTask = taskNameLower.let {
+      it.contains("test") || it.contains("androidtest") || it.contains("unittest")
+    }
+
+    // Include task if it's a Kotlin compile task and either:
+    // 1. includeTests is true, OR
+    // 2. it's not a test task
+    return isKotlinCompile && (includeTests || !isTestTask)
+  }
+}


### PR DESCRIPTION
### 🎯 Goal
Prevent the stability analyzer Gradle plugin from leaking Android Gradle plugin v9 to users of the plugin.

### 🛠 Implementation details

The Gradle plugin uses the `implementation` configuration for `com.android.tools.build:gradle-api`, and that makes Gradle pull in the configured version of AGP when a project uses the CSA Gradle plugin.

This project now uses AGP 9+, but unfortunately not everyone has updated to AGP 9 (or can, for a bit longer), It's enough of a mess that Google even had to make an AI skill to try and help people update.

But the plugin itself doesn't seem to use very recent AGP features, so using the `compileOnly` configuration should be sufficient. At runtime _some_ AGP version will be available.

### Testing

Tested locally:
1. publish this branch to maven local with a custom version
2. set custom version for the plugin in the downstream project's toml file
3. build succeeds, analyzer runs in Android Studio, stability indicators display, Explorer works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds aggregate and per-variant/per-platform "stabilityDump" and "stabilityCheck" tasks with integration into the project check lifecycle and optional lint wiring.
* **Chores**
  * Limits a Gradle API dependency to compile-time only.
* **Refactor**
  * Reorganizes task registration and runtime wiring for clearer platform-specific behavior and simpler maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->