### PR TITLE
Match nullable types in stability configuration

### DIFF
--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityConfigParser.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityConfigParser.kt
@@ -188,7 +188,10 @@ internal class FqNameMatcher(val pattern: String) {
   fun matches(name: String?): Boolean {
     if (pattern == STABILITY_WILDCARD_MULTI) return true
 
-    val nameStr = name?.removeGenerics() ?: return false
+    val nameStr = name
+      ?.removeGenerics()
+      ?.removeSuffix("?") // Support for nullable types
+      ?: return false
     if (key.length > nameStr.length) return false
 
     val suffix = nameStr.substring(key.length)

--- a/stability-gradle/src/test/kotlin/com/skydoves/compose/stability/gradle/GetCustomStableTypesAsRegexTest.kt
+++ b/stability-gradle/src/test/kotlin/com/skydoves/compose/stability/gradle/GetCustomStableTypesAsRegexTest.kt
@@ -279,6 +279,55 @@ class GetCustomStableTypesAsRegexTest {
   }
 
   @Test
+  fun `Match nullable type`() {
+    // Nullability does not affect stability, so a non-nullable pattern should match the
+    // nullable type name (rendered with a trailing `?`) just like the non-nullable one.
+    val patterns = """
+      mypackage.ClassA
+    """.trimIndent()
+
+    val classes = listOf(
+      "mypackage.ClassA",
+      "mypackage.ClassA?",
+      "mypackage.ClassB?",
+      "otherpackage.ClassA?",
+    )
+
+    val result = getMatches(patterns, classes)
+
+    assertEquals(
+      listOf(
+        "mypackage.ClassA",
+        "mypackage.ClassA?",
+      ),
+      result,
+    )
+  }
+
+  @Test
+  fun `Match nullable type with wildcard`() {
+    val patterns = """
+      mypackage.Class*
+    """.trimIndent()
+
+    val classes = listOf(
+      "mypackage.ClassA?",
+      "mypackage.ClassB?",
+      "otherpackage.ClassA?",
+    )
+
+    val result = getMatches(patterns, classes)
+
+    assertEquals(
+      listOf(
+        "mypackage.ClassA?",
+        "mypackage.ClassB?",
+      ),
+      result,
+    )
+  }
+
+  @Test
   fun `Allow dollar numbers and underscores`() {
     val patterns = """
       my_package.Class1.SubclassB
@@ -356,6 +405,34 @@ class GetCustomStableTypesAsRegexTest {
         "GenericClass1",
         "GenericClass1<Class1>",
         "GenericClass1<Class2>",
+      ),
+      result,
+    )
+  }
+
+  @Test
+  fun `Match nullable generic type`() {
+    // A trailing `?` on a generic type sits after the `>`, so it is stripped together with
+    // the generic arguments. A generic pattern should therefore match the nullable generic
+    // type name, the non-nullable one, and a nullable type argument alike.
+    val patterns = """
+      GenericClass1<_>
+    """.trimIndent()
+
+    val classes = listOf(
+      "GenericClass1<Class1>",
+      "GenericClass1<Class1>?",
+      "GenericClass1<Class1?>",
+      "GenericClass2<Class1>?",
+    )
+
+    val result = getMatches(patterns, classes)
+
+    assertEquals(
+      listOf(
+        "GenericClass1<Class1>",
+        "GenericClass1<Class1>?",
+        "GenericClass1<Class1?>",
       ),
       result,
     )


### PR DESCRIPTION
### 🎯 Goal
Fix the issue with the nullable types not matched against stability config #166 

### 🛠 Implementation details
Remove suffix "?" character from types inside the match function

### Preparing a pull request for review
Done

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching to normalize nullable Kotlin type names (trailing `?`) so patterns match nullable and non-nullable forms consistently.

* **Tests**
  * Added unit tests covering nullable type matching, including wildcard and generic-argument nullable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->