### PR TITLE
Fix Android Studio freeze when starting the heatmap on large projects

### DIFF
--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnalyzer.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/StabilityAnalyzer.kt
@@ -18,8 +18,7 @@
 package com.skydoves.compose.stability.idea
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.PsiManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.skydoves.compose.stability.idea.k2.StabilityAnalyzerK2
@@ -34,6 +33,7 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.stubindex.KotlinTypeAliasShortNameIndex
 import org.jetbrains.kotlin.idea.caches.resolve.resolveMainReference
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.psi.KtClass
@@ -776,42 +776,19 @@ internal object StabilityAnalyzer {
     aliasName: String,
     fqNameHint: String?,
   ): KtTypeAlias? {
-    val psiManager = PsiManager.getInstance(project)
-    val packageHint = fqNameHint?.substringBeforeLast('.', "")
-
-    var found: KtTypeAlias? = null
-
-    // Use content roots to avoid relying on stub indexes (stable in tests + dumb mode).
-    val roots = ProjectRootManager.getInstance(project).contentRoots
-
-    roots.forEach { root ->
-      VfsUtilCore.iterateChildrenRecursively(
-        root,
-        { vf -> vf.isDirectory || vf.extension == "kt" },
-      ) { vf ->
-        if (vf.isDirectory) return@iterateChildrenRecursively true
-
-        val psi = psiManager.findFile(vf) as? KtFile ?: return@iterateChildrenRecursively true
-        if (packageHint?.isNotEmpty() == true && psi.packageFqName.asString() != packageHint) {
-          return@iterateChildrenRecursively true
-        }
-
-        val alias = PsiTreeUtil.findChildrenOfType(psi, KtTypeAlias::class.java)
-          .firstOrNull { it.name == aliasName }
-          ?: return@iterateChildrenRecursively true
-
-        if (fqNameHint == null || alias.fqName?.asString() == fqNameHint) {
-          found = alias
-          return@iterateChildrenRecursively false // stop traversal
-        }
-
-        true
+    // Stub-index lookup only — never iterate/parse project files here (froze the IDE on
+    // large projects, Issue #168). Returns null in dumb mode; the verdict degrades to
+    // RUNTIME until indexes are ready.
+    return runCatching {
+      val scope = GlobalSearchScope.projectScope(project)
+      val candidates = KotlinTypeAliasShortNameIndex.get(aliasName, project, scope)
+      if (fqNameHint != null) {
+        candidates.firstOrNull { it.fqName?.asString() == fqNameHint }
+          ?: candidates.firstOrNull()
+      } else {
+        candidates.firstOrNull()
       }
-
-      if (found != null) return found
-    }
-
-    return found
+    }.getOrNull()
   }
 
   /**

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/heatmap/HeatmapInlayManager.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/heatmap/HeatmapInlayManager.kt
@@ -21,6 +21,8 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.Inlay
@@ -92,6 +94,7 @@ internal class HeatmapInlayManager(
     val offset: Int,
     val displayText: String,
     val color: Color,
+    val tooltip: String,
   )
 
   /**
@@ -103,6 +106,9 @@ internal class HeatmapInlayManager(
 
   @Volatile
   private var refreshTask: ScheduledFuture<*>? = null
+
+  /** True while a snapshot→compute→apply refresh cycle is running (ticks are skipped). */
+  private val refreshInFlight = java.util.concurrent.atomic.AtomicBoolean(false)
 
   @Volatile
   private var listenersRegistered = false
@@ -215,12 +221,14 @@ internal class HeatmapInlayManager(
           try {
             if (project.isDisposed) return@scheduleWithFixedDelay
             service.flushParser()
+            // Skip the tick while a previous refresh is still computing.
+            if (!refreshInFlight.compareAndSet(false, true)) return@scheduleWithFixedDelay
             ApplicationManager.getApplication().invokeLater(
-              { refreshAllEditors() },
+              { snapshotEditorsAndRefresh() },
               ModalityState.any(),
             )
           } catch (_: Exception) {
-            // Guard against disposal races
+            refreshInFlight.set(false)
           }
         },
         500L,
@@ -247,30 +255,77 @@ internal class HeatmapInlayManager(
     refreshTask = null
   }
 
-  // ── Core logic (all runs on EDT) ────────────────────────────────────────
+  // ── Core logic ─────────────────────────────────────────────────────────────
+  // Refresh runs in three stages — snapshot editors (EDT) → compute desired inlays
+  // (pooled thread, read actions) → apply inlay mutations (EDT) — so the EDT never
+  // runs PSI/K2 analysis (Issue #168).
 
-  private fun refreshAllEditors() {
-    if (project.isDisposed) return
-    if (!settings.isHeatmapEnabled) return
-    if (!service.isRunning && !settings.showHeatmapWhenStopped) {
-      clearAllInlays()
-      return
-    }
+  private fun snapshotEditorsAndRefresh() {
+    try {
+      if (project.isDisposed || !settings.isHeatmapEnabled) {
+        refreshInFlight.set(false)
+        return
+      }
+      if (!service.isRunning && !settings.showHeatmapWhenStopped) {
+        clearAllInlays()
+        refreshInFlight.set(false)
+        return
+      }
+      // Keep previous inlays during indexing; retry on the next tick.
+      if (DumbService.getInstance(project).isDumb) {
+        refreshInFlight.set(false)
+        return
+      }
 
-    for (editor in EditorFactory.getInstance().allEditors) {
-      if (editor.isDisposed || editor.project != project) continue
-      refreshEditor(editor)
-    }
+      val editors = EditorFactory.getInstance().allEditors
+        .filter { !it.isDisposed && it.project == project }
 
-    // Clean up entries for disposed editors
-    editorState.keys.removeAll { key ->
-      EditorFactory.getInstance().allEditors.none { System.identityHashCode(it) == key }
+      // Clean up entries for disposed editors.
+      editorState.keys.removeAll { key ->
+        editors.none { System.identityHashCode(it) == key }
+      }
+
+      com.intellij.util.concurrency.AppExecutorUtil.getAppExecutorService().execute {
+        computeAndApply(editors)
+      }
+    } catch (t: Throwable) {
+      refreshInFlight.set(false)
+      throw t
     }
   }
 
-  private fun refreshEditor(editor: Editor) {
+  /** Stage 2 (pooled thread): all analysis happens here, inside read actions. */
+  private fun computeAndApply(editors: List<Editor>) {
+    try {
+      val computed = editors.mapNotNull { editor ->
+        if (editor.isDisposed || project.isDisposed) return@mapNotNull null
+        val desired = computeDesiredInlays(editor) ?: return@mapNotNull null
+        editor to desired
+      }
+      ApplicationManager.getApplication().invokeLater(
+        {
+          try {
+            if (!project.isDisposed) {
+              computed.forEach { (editor, desired) ->
+                if (!editor.isDisposed) applyDesiredInlays(editor, desired)
+              }
+            }
+          } finally {
+            refreshInFlight.set(false)
+          }
+        },
+        ModalityState.any(),
+      )
+    } catch (t: Throwable) {
+      refreshInFlight.set(false)
+      if (t is ProcessCanceledException) throw t
+    }
+  }
+
+  private fun computeDesiredInlays(editor: Editor): Map<String, DesiredInlay>? {
     val realityEnabled = settings.isRealityCheckEnabled
     val anchors = runReadAction {
+      if (project.isDisposed || editor.isDisposed) return@runReadAction null
       val psiFile = PsiDocumentManager.getInstance(project)
         .getPsiFile(editor.document) as? KtFile ?: return@runReadAction null
       PsiTreeUtil.findChildrenOfType(psiFile, KtNamedFunction::class.java)
@@ -281,13 +336,10 @@ internal class HeatmapInlayManager(
           val verdict = if (realityEnabled) cachedVerdict(fn) else null
           ComposableAnchor(name, anchor.textRange.startOffset, verdict)
         }
-    } ?: return
+    } ?: return null
 
-    val editorKey = System.identityHashCode(editor)
-    val entries = editorState.getOrPut(editorKey) { mutableMapOf() }
-
-    // Figure out what should be shown. The reality grade is folded into displayText so the
-    // cache-diff below invalidates the inlay on a grade-only change, not just a count change.
+    // The reality grade is folded into displayText so the apply-stage diff invalidates on
+    // grade-only changes; the tooltip is prebuilt so the EDT never touches live data.
     val desired = mutableMapOf<String, DesiredInlay>()
     for (anchor in anchors) {
       val data = service.getHeatmapData(anchor.name) ?: continue
@@ -296,8 +348,16 @@ internal class HeatmapInlayManager(
         offset = anchor.offset,
         displayText = buildDisplayText(data, reality),
         color = severityColor(data, reality),
+        tooltip = buildTooltipHtml(data),
       )
     }
+    return desired
+  }
+
+  /** Stage 3 (EDT): inlay-model mutations only — no analysis, no live-data access. */
+  private fun applyDesiredInlays(editor: Editor, desired: Map<String, DesiredInlay>) {
+    val editorKey = System.identityHashCode(editor)
+    val entries = editorState.getOrPut(editorKey) { mutableMapOf() }
 
     // Remove inlays for composables no longer needed
     val toRemoveNames = entries.keys - desired.keys
@@ -319,10 +379,8 @@ internal class HeatmapInlayManager(
       // Text changed or inlay is new/invalid: dispose old, create new
       existing?.inlay?.let { if (it.isValid) it.dispose() }
 
-      val data = service.getHeatmapData(name) ?: continue
-      val tooltip = buildTooltipHtml(data)
       val renderer =
-        HeatmapBlockRenderer(d.displayText, d.color, editor, tooltip)
+        HeatmapBlockRenderer(d.displayText, d.color, editor, d.tooltip)
       val inlay = editor.inlayModel.addBlockElement(
         d.offset,
         true, // relatesToPrecedingText

--- a/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/ComposableStabilityCollector.kt
+++ b/compose-stability-analyzer-idea/src/main/kotlin/com/skydoves/compose/stability/idea/toolwindow/ComposableStabilityCollector.kt
@@ -21,14 +21,11 @@ import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.psi.PsiManager
-import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import com.skydoves.compose.stability.idea.settings.StabilitySettingsState
-import org.jetbrains.kotlin.idea.KotlinFileType
-import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.idea.stubindex.KotlinFunctionShortNameIndex
+import org.jetbrains.kotlin.idea.stubindex.KotlinTopLevelFunctionFqnNameIndex
+import org.jetbrains.kotlin.idea.stubindex.KotlinTopLevelPropertyFqnNameIndex
 import java.io.File
 
 /**
@@ -140,7 +137,8 @@ public class ComposableStabilityCollector(private val project: Project) {
   }
 
   /**
-   * Finds the source file location for a composable function.
+   * Finds the source file location for a composable function via stub indexes —
+   * never by iterating/parsing project files (Issue #168).
    */
   private fun findSourceLocation(
     qualifiedName: String,
@@ -148,50 +146,24 @@ public class ComposableStabilityCollector(private val project: Project) {
   ): Triple<String, String, Int> {
     try {
       val scope = GlobalSearchScope.projectScope(project)
-      val psiManager = PsiManager.getInstance(project)
 
-      val packageName = qualifiedName.substringBeforeLast(".$simpleName", "")
-      val allFiles = FileTypeIndex.getFiles(
-        KotlinFileType.INSTANCE,
-        scope,
-      )
+      val declaration =
+        KotlinTopLevelFunctionFqnNameIndex.get(qualifiedName, project, scope).firstOrNull()
+          ?: KotlinTopLevelPropertyFqnNameIndex.get(qualifiedName, project, scope).firstOrNull()
+          ?: KotlinFunctionShortNameIndex.get(simpleName, project, scope)
+            .firstOrNull { it.fqName?.asString() == qualifiedName }
+          ?: return Triple("Unknown", "Unknown.kt", 0)
 
-      for (virtualFile in allFiles) {
-        val ktFile = psiManager.findFile(virtualFile) as? KtFile ?: continue
-        if (ktFile.packageFqName.asString() != packageName) {
-          continue
-        }
-
-        // Search for named functions
-        ktFile.declarations.filterIsInstance<KtNamedFunction>().forEach { function ->
-          if (function.name == simpleName) {
-            val line = try {
-              val document = com.intellij.psi.PsiDocumentManager.getInstance(project)
-                .getDocument(ktFile)
-              document?.getLineNumber(function.textOffset)?.plus(1) ?: 0
-            } catch (e: Exception) {
-              0
-            }
-            return Triple(virtualFile.path, virtualFile.name, line)
-          }
-        }
-
-        // Search for properties (for composable properties/getters)
-        ktFile.declarations.filterIsInstance<KtProperty>().forEach { property ->
-          if (property.name == simpleName) {
-            val line = try {
-              val document = com.intellij.psi.PsiDocumentManager.getInstance(project)
-                .getDocument(ktFile)
-              document?.getLineNumber(property.textOffset)?.plus(1) ?: 0
-            } catch (e: Exception) {
-              0
-            }
-            return Triple(virtualFile.path, virtualFile.name, line)
-          }
-        }
+      val virtualFile = declaration.containingFile?.virtualFile
+        ?: return Triple("Unknown", "Unknown.kt", 0)
+      val line = try {
+        val document = com.intellij.psi.PsiDocumentManager.getInstance(project)
+          .getDocument(declaration.containingFile)
+        document?.getLineNumber(declaration.textOffset)?.plus(1) ?: 0
+      } catch (e: Exception) {
+        0
       }
-
-      return Triple("Unknown", "Unknown.kt", 0)
+      return Triple(virtualFile.path, virtualFile.name, line)
     } catch (e: Exception) {
       return Triple("Unknown", "Unknown.kt", 0)
     }


### PR DESCRIPTION
### 🎯 Goal
Fix #168 — Android Studio deadlocks instantly and unrecoverably when starting the recomposition heatmap on large projects (reported: ~1650 composables / ~75 modules, 100% repro).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Faster and more reliable resolution for type aliases and source locations using optimized project lookups.
  * Heatmap inlay refresh rewritten into snapshot → background compute → EDT apply stages to reduce UI blocking and prevent overlapping refreshes.
  * Inlay tooltips are precomputed during background analysis so UI updates apply more quickly and smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->