### PR TITLE
Report only unstable new composables under ignoreNonRegressiveChanges

### DIFF
--- a/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityComparison.kt
+++ b/stability-gradle/src/main/kotlin/com/skydoves/compose/stability/gradle/StabilityComparison.kt
@@ -23,9 +23,15 @@ internal fun compareStability(
 ): List<StabilityDifference> {
   val differences = mutableListOf<StabilityDifference>()
 
-  // Check for new functions
+  // Check for new functions. Under ignoreNonRegressiveChanges, a new composable is a regression
+  // only if it introduces an unstable parameter. Being non-restartable or opting out of skipping
+  // (@NonSkippableComposable) with all-stable parameters is not a regression, so it must not use the
+  // skippability-oriented isStable() here, which would wrongly report those stable composables
+  // (issue #192).
   current.keys.subtract(reference.keys).forEach { functionName ->
-    if (!ignoreNonRegressiveChanges || !current.getValue(functionName).isStable(forceStableTypes)) {
+    if (!ignoreNonRegressiveChanges ||
+      current.getValue(functionName).hasUnstableParameter(forceStableTypes)
+    ) {
       val parametersWithFixedStability = current.getValue(functionName).parameters
         .map { parameter ->
           parameter.copy(
@@ -138,6 +144,16 @@ private fun StabilityEntry.isStable(forceStableTypes: List<FqNameMatcher>): Bool
       parameters.all { it.isStable(forceStableTypes) } &&
       parameters.any { it.stability != "STABLE" }
     )
+
+/**
+ * Whether the composable has at least one unstable parameter, i.e. it introduces instability. This
+ * is the signal used to decide whether a *new* composable is a regression under
+ * `ignoreNonRegressiveChanges`, independently of skippability/restartability: a composable whose
+ * parameters are all stable is not a regression even when it is non-restartable or opts out of
+ * skipping (issue #192). A parameterless composable introduces no instability.
+ */
+private fun StabilityEntry.hasUnstableParameter(forceStableTypes: List<FqNameMatcher>): Boolean =
+  parameters.any { !it.isStable(forceStableTypes) }
 
 private fun ParameterInfo.isStable(forceStableTypes: List<FqNameMatcher>): Boolean =
   stability == "STABLE" ||

--- a/stability-gradle/src/test/kotlin/com/skydoves/compose/stability/gradle/StabilityComparisonTest.kt
+++ b/stability-gradle/src/test/kotlin/com/skydoves/compose/stability/gradle/StabilityComparisonTest.kt
@@ -55,9 +55,11 @@ class StabilityComparisonTest {
 
   @Test
   fun testCompareStability_newFunctionWithRegressionFiltering() {
+    // Under regression filtering, a new composable is reported only when it introduces an unstable
+    // parameter, not because of its skippability (issue #192).
     val current = mapOf(
-      createEntry("com.example.New1", skippable = true),
-      createEntry("com.example.New2", skippable = false),
+      createEntry("com.example.New1", params = listOf(ParameterInfo("a", "A", "STABLE"))),
+      createEntry("com.example.New2", params = listOf(ParameterInfo("b", "B", "UNSTABLE"))),
     )
 
     val reference = emptyMap<String, StabilityEntry>()
@@ -67,6 +69,50 @@ class StabilityComparisonTest {
     assertEquals(1, differences.size)
     assertTrue(differences[0] is StabilityDifference.NewFunction)
     assertEquals("com.example.New2", (differences[0] as StabilityDifference.NewFunction).name)
+  }
+
+  // Issue #192: with ignoreNonRegressiveChanges, a new composable whose parameters are all stable
+  // must NOT be reported, even when it is non-restartable (restartable=false, skippable=false) or a
+  // @NonSkippableComposable (restartable=true, skippable=false). Only a genuinely unstable parameter
+  // is a regression.
+  @Test
+  fun testCompareStability_newStableNonSkippableFunctionsAreIgnored() {
+    val current = mapOf(
+      // Non-restartable composable with a stable parameter.
+      createEntry(
+        "com.example.NonRestartableDemo",
+        skippable = false,
+        restartable = false,
+        params = listOf(ParameterInfo("text", "kotlin.String", "STABLE")),
+      ),
+      // @NonSkippableComposable (restartable, opts out of skipping) with a stable parameter.
+      createEntry(
+        "com.example.NonSkippableDemo",
+        skippable = false,
+        restartable = true,
+        params = listOf(ParameterInfo("text", "kotlin.String", "STABLE")),
+      ),
+      // Non-restartable composable with no parameters (e.g. @ReadOnlyComposable / non-Unit return).
+      createEntry(
+        "com.example.readOnlyDemo",
+        skippable = false,
+        restartable = false,
+      ),
+      // Control: a new composable that actually introduces an unstable parameter is still reported.
+      createEntry(
+        "com.example.UnstableDemo",
+        skippable = false,
+        restartable = true,
+        params = listOf(ParameterInfo("user", "com.example.MutableUser", "UNSTABLE")),
+      ),
+    )
+
+    val reference = emptyMap<String, StabilityEntry>()
+
+    val differences = compareStability(current, reference, ignoreNonRegressiveChanges = true)
+
+    val reported = differences.filterIsInstance<StabilityDifference.NewFunction>().map { it.name }
+    assertEquals(listOf("com.example.UnstableDemo"), reported)
   }
 
   @Test


### PR DESCRIPTION
Fixes #192.

## Problem
Reported by @matejdro: with `ignoreNonRegressiveChanges = true`, `stabilityCheck` reports new composables that have only stable parameters, e.g.

```
+ com.skydoves.myapplication.NonRestartableDemo (new composable):
    text: STABLE
+ com.skydoves.myapplication.NonSkippableDemo (new composable):
    text: STABLE
```

These are not regressions (their parameters are all `STABLE`), so they should be filtered out. This worked in 0.10.0 and broke in 0.11.0.

## Root cause
In #184 the `StabilityEntry.isStable()` helper became a skippability oriented signal: it returns `false` for a composable that is non-restartable, or that opts out of skipping (`@NonSkippableComposable`), even when all its parameters are stable. That change was correct for the `SkippabilityChanged` diff, but the new-composable filter reused the same helper, so those all-stable composables started being reported as new functions under `ignoreNonRegressiveChanges`.

## Fix
Filter new composables on whether they introduce an unstable parameter (`hasUnstableParameter`), independently of skippable/restartable. A composable whose parameters are all stable is not a regression, even when it is non-restartable or non-skippable. Skippability and restartability regressions of existing composables are still detected via `isStable()` / `SkippabilityChanged` / `RestartabilityChanged`.

## Tests
- New `testCompareStability_newStableNonSkippableFunctionsAreIgnored` reproduces the issue: new non-restartable / `@NonSkippableComposable` composables with stable parameters are not reported, while a new composable with an unstable parameter still is.
- Updated `testCompareStability_newFunctionWithRegressionFiltering` to assert on parameter instability rather than skippability.
- Full `StabilityComparisonTest` passes (38 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability comparison accuracy for newly added composables when regression filtering is enabled.
  * Newly added composables are now reported only if they introduce at least one unstable parameter.
  * Avoids false positives caused by differences in skippability, restartability, or opting out of skipping when all parameters are stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->